### PR TITLE
Parse module basics

### DIFF
--- a/src/Parser/ParseAST.rsc
+++ b/src/Parser/ParseAST.rsc
@@ -1,0 +1,7 @@
+module Parser::ParseAST
+
+import Syntax::Abstract::AST;
+import Parser::ParseCode;
+import ParseTree;
+
+public Module parseModule(str code) = implode(#Module, parseCode(code));

--- a/src/Parser/ParseCode.rsc
+++ b/src/Parser/ParseCode.rsc
@@ -1,0 +1,6 @@
+module Parser::ParseCode
+
+import Syntax::Concrete::Grammar;
+import ParseTree;
+
+public Tree parseCode(str code) = parse(#Module, code);

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -1,1 +1,10 @@
 module Syntax::Abstract::AST
+
+data Module = \module(str name, set[Import] imports)
+            ;
+
+data Import = importInternal(str target, str \artifactType)
+            | importInternal(str target, str \artifactType, str \alias)
+            | importExternal(str target, str \artifactType, str \module)
+            | importExternal(str target, str \artifactType, str \module, str \alias)
+            ;

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -1,1 +1,16 @@
 module Syntax::Concrete::Grammar
+
+lexical LAYOUT = [\t-\n\r\ ];
+lexical Identifier =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
+lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | "util" | "service";
+
+layout LAYOUTLIST = LAYOUT* !>> [\t-\n\r\ ] ;
+
+start syntax Module = \module: "module" Identifier name ";" Imports* imports
+                    | \module: "module" Identifier name ";" Imports* imports Artifact artifact
+                    ;
+
+syntax Imports = importInternal: "use" Identifier target ImportArtifactType artifactType ";"
+               | importInternal: "use" Identifier target ImportArtifactType artifactType "as" Identifier alias ";"
+               | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module ";"
+               | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module "as" Identifier alias ";"

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -7,10 +7,10 @@ lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | 
 layout LAYOUTLIST = LAYOUT* !>> [\t-\n\r\ ] ;
 
 start syntax Module = \module: "module" Identifier name ";" Imports* imports
-                    | \module: "module" Identifier name ";" Imports* imports Artifact artifact
                     ;
 
 syntax Imports = importInternal: "use" Identifier target ImportArtifactType artifactType ";"
                | importInternal: "use" Identifier target ImportArtifactType artifactType "as" Identifier alias ";"
                | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module ";"
                | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module "as" Identifier alias ";"
+               ;

--- a/src/Test/Parser/ModuleBasics.rsc
+++ b/src/Test/Parser/ModuleBasics.rsc
@@ -1,0 +1,84 @@
+module Test::Parser::ModuleBasics
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool testShouldParseModule()
+{
+    str code = "module Example;";
+    
+    Module ast = parseModule(code);
+    
+    return ast == \module("Example", {});
+}
+
+test bool testShouldParseModuleWithUnderscoresInName()
+{
+    str code = "module my_example_module;";
+    
+    Module ast = parseModule(code);
+    
+    return ast == \module("my_example_module", {});
+}
+
+test bool testShouldNotParseTwoModuleDeclarations()
+{
+    str code = "module my_example_module;
+               'module this_should_throw_error;";
+             
+    try parseModule(code);
+    catch ParseError(x): return true;
+    
+    return false;
+}
+
+test bool testShouldParseModuleWithImportFromOtherModule()
+{
+    str code = "module Example;
+               'use User entity from Auth;";
+    
+    return parseModule(code) == \module("Example", {importExternal("User", "entity", "Auth")});
+}
+
+test bool testShouldParseModuleWithImportFromSameModule()
+{
+    str code = "module Example;
+               'use User entity;";
+    
+    return parseModule(code) == \module("Example", {importInternal("User", "entity")});
+}
+
+test bool testShouldParseModuleWithImportFromSameModuleWithAlias()
+{
+    str code = "module Example;
+               'use User entity as UserEntity;";
+    
+    return parseModule(code) == \module("Example", {importInternal("User", "entity", "UserEntity")});
+}
+
+test bool testShouldParseModuleWithImportFromOtherModuleWithAlias()
+{
+    str code = "module Example; 
+               'use User entity from Auth as UserEntity;";
+    
+    return parseModule(code) == \module("Example", {importExternal("User", "entity", "Auth", "UserEntity")});
+}
+
+test bool testShouldParseModuleWithCompositeImports()
+{
+    str code = "module Example;
+               'use User entity from Auth as UserEntity;
+               'use Money value;
+               'use Money collection as MoneySet;
+               'use Language entity from I18n;";
+               
+   set[Import] expectedImports = {
+        importExternal("User", "entity", "Auth", "UserEntity"),
+        importInternal("Money", "value"),
+        importInternal("Money", "collection", "MoneySet"),
+        importExternal("Language", "entity", "I18n")
+   };
+   
+   return parseModule(code) == \module("Example", expectedImports);
+}


### PR DESCRIPTION
#### Description

Added grammar for module declarations and artifact imports.
#### Module declaration

Module declaration done by:

```
 module Name;
```

Where _Name_ is the name of the module and it can consist of non-digit starting alphanumeric string, underscores allowed. 
#### Artifact Imports

Artifacts from the same (and other) modules can be imported following syntax:

```
module Name;
Import*;
```

Where `Import` has the following syntax:
1. `use Artifact_Name Artifact_Type ;`
2. `use Artifact_Name Artifact_Type as Artifact_Alias;`
3. `use Artifact_Name Artifact_Type from Module_Name ;`
4. `use Artifact_Name Artifact_Type from Module_Name as Artifact_Alias;`

Where: 
- `Artifact_Name` is identifier (same rules as for module name)
- `Artifact_Type` can be `entity`, `value`, `repository`, `collection`, `util` or `service` (**list will be extended in future**)
- `Module_Name` is a name of external module
- `Artifact_Alias` is alias to **replace** the original name of the imported artifact
#### Examples

```
module Example;

use User entity from Auth as UserEntity;
use Money value;
use Money collection as MoneySet;
use Language entity from I18n;
```
