### PR TITLE
Entity grammar basics

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -1,6 +1,7 @@
 module Syntax::Abstract::AST
 
 data Module = \module(str name, set[Import] imports)
+            | \module(str name, set[Import] imports, Artifact artifact)
             ;
 
 data Import = importInternal(str target, str \artifactType)
@@ -8,3 +9,5 @@ data Import = importInternal(str target, str \artifactType)
             | importExternal(str target, str \artifactType, str \module)
             | importExternal(str target, str \artifactType, str \module, str \alias)
             ;
+
+data Artifact = entity(str name);

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -7,6 +7,7 @@ lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | 
 layout LAYOUTLIST = LAYOUT* !>> [\t-\n\r\ ] ;
 
 start syntax Module = \module: "module" Identifier name ";" Imports* imports
+                    | \module: "module" Identifier name ";" Imports* imports Artifact artifact
                     ;
 
 syntax Imports = importInternal: "use" Identifier target ImportArtifactType artifactType ";"
@@ -14,3 +15,6 @@ syntax Imports = importInternal: "use" Identifier target ImportArtifactType arti
                | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module ";"
                | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module "as" Identifier alias ";"
                ;
+
+// Entity grammar
+syntax Artifact = entity: "entity" Identifier name "{" "}";

--- a/src/Test/All.rsc
+++ b/src/Test/All.rsc
@@ -1,0 +1,4 @@
+module Test::All
+
+extend Test::Parser::ModuleBasics;
+extend Test::Parser::Entity::Basics;

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -1,0 +1,32 @@
+module Test::Parser::Entity::Basics
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool testShouldParseEmptyEntityWithName()
+{
+    str code = "module Example;
+               'entity User {}";
+
+    return parseModule(code) == \module("Example", {}, entity("User"));
+}
+
+test bool testShouldParseEmptyEntityWithModuleImports()
+{
+    str code = "module Example;
+               'use User entity from Auth as UserEntity;
+               'use Money value;
+               'use Money collection as MoneySet;
+               'use Language entity from I18n;
+               'entity User {}";
+
+   set[Import] expectedImports = {
+        importExternal("User", "entity", "Auth", "UserEntity"),
+        importInternal("Money", "value"),
+        importInternal("Money", "collection", "MoneySet"),
+        importExternal("Language", "entity", "I18n")
+   };
+
+    return parseModule(code) == \module("Example", expectedImports, entity("User"));
+}

--- a/src/Tests.rsc
+++ b/src/Tests.rsc
@@ -1,0 +1,3 @@
+module Tests
+
+extend Test::All;


### PR DESCRIPTION
#### Description

Adds possibility of declare empty (at this moment) entity declarations. 
#### Syntax
1. `entity Name { }` where _Name_ is identifier.
