### PR TITLE
Added annotations for entities

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -10,4 +10,7 @@ data Import = importInternal(str target, str \artifactType)
             | importExternal(str target, str \artifactType, str \module, str \alias)
             ;
 
-data Artifact = entity(str name);
+data Artifact = entity(set[Annotation] annotations, str name);
+
+data Annotation = annoTable(str name)
+                | index(str name, set[str] columns);

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -1,6 +1,7 @@
 module Syntax::Concrete::Grammar
 
 lexical LAYOUT = [\t-\n\r\ ];
+lexical TableName = [a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
 lexical Identifier =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
 lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | "util" | "service";
 
@@ -17,4 +18,12 @@ syntax Imports = importInternal: "use" Identifier target ImportArtifactType arti
                ;
 
 // Entity grammar
-syntax Artifact = entity: "entity" Identifier name "{" "}";
+
+syntax EntityAnno = annoTable: "@table(" "name=" TableName name ")"
+                  | index: "@index(" Identifier name "," "{" {EntityAnnoIndexColumns ","}* columns "}" ")"
+                  ;
+
+syntax EntityAnnoIndexColumns = Identifier;
+
+syntax Artifact = entity: EntityAnno* annotations "entity" Identifier name "{" "}";
+

--- a/src/Test/All.rsc
+++ b/src/Test/All.rsc
@@ -2,3 +2,4 @@ module Test::All
 
 extend Test::Parser::ModuleBasics;
 extend Test::Parser::Entity::Basics;
+extend Test::Parser::Entity::Annotations;

--- a/src/Test/Parser/Entity/Annotations.rsc
+++ b/src/Test/Parser/Entity/Annotations.rsc
@@ -1,0 +1,44 @@
+module Test::Parser::Entity::Annotations
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool testShouldParseTableNameAnnotationForEntity()
+{
+    str code = "module Example;
+               '@table(name=users)
+               'entity User {}";
+
+    return parseModule(code) == \module("Example", {}, entity({annoTable("users")}, "User"));
+}
+
+test bool testShouldParseIndexesAnnotationForEntity()
+{
+    str code = "module Example;
+               '@index(my_index, {name, email})
+               '@index(second_index, {quantity, total})
+               'entity User {}";
+
+    Artifact expectedEntity = entity({index("my_index", {"name", "email"}), index("second_index", {"quantity", "total"})}, "User");
+
+    return parseModule(code) == \module("Example", {}, expectedEntity);
+}
+
+test bool testShouldParseCompositeAnnotationForEntity()
+{
+    str code = "module Example;
+               '@index(my_index, {name, email})
+               '@index(second_index, {quantity, total})
+               '@table(name=my_users_table)
+               'entity User {}";
+
+    Artifact expectedEntity = entity(
+        {
+            index("my_index", {"name", "email"}),
+            index("second_index", {"quantity", "total"}),
+            annoTable("my_users_table")
+        }, "User");
+
+    return parseModule(code) == \module("Example", {}, expectedEntity);
+}

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -9,7 +9,7 @@ test bool testShouldParseEmptyEntityWithName()
     str code = "module Example;
                'entity User {}";
 
-    return parseModule(code) == \module("Example", {}, entity("User"));
+    return parseModule(code) == \module("Example", {}, entity({}, "User"));
 }
 
 test bool testShouldParseEmptyEntityWithModuleImports()
@@ -28,5 +28,6 @@ test bool testShouldParseEmptyEntityWithModuleImports()
         importExternal("Language", "entity", "I18n")
    };
 
-    return parseModule(code) == \module("Example", expectedImports, entity("User"));
+    return parseModule(code) == \module("Example", expectedImports, entity({}, "User"));
 }
+


### PR DESCRIPTION
#### Description

Enables annotation for the `entity` artifact.
#### Syntax

Two annotations are now available:
- `@table(name=Table_Name)` where _Table_Name_ is identifier
- `@index(Index_Name, {Column`<sub>`1`</sub>`, Column`<sub>`2`</sub>`, ..., Column`<sub>`n`</sub>`})` where _Index_Name_ and _Column_ are identifiers.
#### Examples

```
module Example;

@index(my_index, {name, email})
@index(second_index, {quantity, total})
@table(name=my_users_table)
entity User {}
```
