### PR TITLE
Added entity values support + entity value annotations

### DIFF
--- a/src/Parser/ParseAST.rsc
+++ b/src/Parser/ParseAST.rsc
@@ -4,5 +4,5 @@ import Syntax::Abstract::AST;
 import Parser::ParseCode;
 import ParseTree;
 
-public Module parseModule(str code) = implode(#Module, parseCode(code));
-public Module parseModule(loc file) = implode(#Module, parseFile(file));
+public Declaration parseModule(str code) = implode(#Declaration, parseCode(code));
+public Declaration parseModule(loc file) = implode(#Declaration, parseFile(file));

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -1,16 +1,20 @@
 module Syntax::Abstract::AST
 
-data Module = \module(str name, set[Import] imports)
-            | \module(str name, set[Import] imports, Artifact artifact)
-            ;
+data Declaration = \module(str name, set[Declaration] imports)
+                 | \module(str name, set[Declaration] imports, Declaration artifact)
+                 | importInternal(str target, str \artifactType)
+                 | importInternal(str target, str \artifactType, str \alias)
+                 | importExternal(str target, str \artifactType, str \module)
+                 | importExternal(str target, str \artifactType, str \module, str \alias)
+                 // artifacts
+                 | entity(set[Declaration] annotations, str name, set[Declaration] values)
+                 | entity(str name, set[Declaration] values)
+                 | entityValue(set[Declaration] annotations, str \type, str name)
+                 | entityValue(set[Declaration] annotations, str \type, str name, set[str] valueProperties)
+                 // annotations
+                 | annoTable(str name)
+                 | annoField(set[Expression] pairs)
+                 | index(str name, set[str] columns)
+                 ;
 
-data Import = importInternal(str target, str \artifactType)
-            | importInternal(str target, str \artifactType, str \alias)
-            | importExternal(str target, str \artifactType, str \module)
-            | importExternal(str target, str \artifactType, str \module, str \alias)
-            ;
-
-data Artifact = entity(set[Annotation] annotations, str name);
-
-data Annotation = annoTable(str name)
-                | index(str name, set[str] columns);
+data Expression = annoPair(str key, str \value);

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -1,11 +1,10 @@
 module Syntax::Concrete::Grammar
 
-lexical LAYOUT = [\t-\n\r\ ];
-lexical TableName = [a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
-lexical Identifier =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
-lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | "util" | "service";
+// Define layout
 
 layout LAYOUTLIST = LAYOUT* !>> [\t-\n\r\ ] ;
+
+// Start grammar
 
 start syntax Module = \module: "module" Identifier name ";" Imports* imports
                     | \module: "module" Identifier name ";" Imports* imports Artifact artifact
@@ -17,13 +16,44 @@ syntax Imports = importInternal: "use" Identifier target ImportArtifactType arti
                | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module "as" Identifier alias ";"
                ;
 
-// Entity grammar
+// Artifacts grammar
 
-syntax EntityAnno = annoTable: "@table(" "name=" TableName name ")"
-                  | index: "@index(" Identifier name "," "{" {EntityAnnoIndexColumns ","}* columns "}" ")"
+syntax Artifact = entity: EntityAnno* annotations "entity" Identifier name "{" EntityValue* values "}"
+                ;
+
+syntax EntityValue = entityValue: EntityValueAnno* annotations "value" Identifier type Identifier name ";"
+                   | entityValue: EntityValueAnno* annotations "value" Identifier type Identifier name "with" "{" {ValueProperties ","}* "}" ";"
+                   ;
+
+syntax EntityAnno = annoTable: "@table(" "name=" Name name ")"
+                  | index: "@index(" Identifier name "," "{" {Identifier ","}* columns "}" ")"
                   ;
 
-syntax EntityAnnoIndexColumns = Identifier;
+syntax EntityValueAnno = annoField: "@field(" {AnnotationPair ","}* pairs ")";
 
-syntax Artifact = entity: EntityAnno* annotations "entity" Identifier name "{" "}";
+syntax AnnotationPair = annoPair: Identifier key ":" Name value;
+
+// Lexical tokens
+
+lexical LAYOUT = [\t-\n\r\ ];
+lexical Name = [a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
+lexical Identifier =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
+lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | "util" | "service";
+lexical ValueProperties = "get" | "set" | "add" | "clear" ;
+
+lexical UnicodeEscape
+      = utf16: "\\" [u] [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f]
+    | utf32: "\\" [U] (("0" [0-9 A-F a-f]) | "10") [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f] // 24 bits
+    | ascii: "\\" [a] [0-7] [0-9A-Fa-f]
+    ;
+
+lexical StringCharacter
+    = "\\" [\" \' \< \> \\ b f n r t]
+    | UnicodeEscape
+    | ![\" \' \< \> \\]
+    | [\n][\ \t \u00A0 \u1680 \u2000-\u200A \u202F \u205F \u3000]* [\'] // margin
+    ;
+
+
+lexical StringConstant = "\"" StringCharacter* chars "\"" ;
 

--- a/src/Test/All.rsc
+++ b/src/Test/All.rsc
@@ -3,3 +3,5 @@ module Test::All
 extend Test::Parser::ModuleBasics;
 extend Test::Parser::Entity::Basics;
 extend Test::Parser::Entity::Annotations;
+extend Test::Parser::Entity::Values;
+

--- a/src/Test/Parser/Entity/Annotations.rsc
+++ b/src/Test/Parser/Entity/Annotations.rsc
@@ -8,9 +8,9 @@ test bool testShouldParseTableNameAnnotationForEntity()
 {
     str code = "module Example;
                '@table(name=users)
-               'entity User {}";
+               'entity User { }";
 
-    return parseModule(code) == \module("Example", {}, entity({annoTable("users")}, "User"));
+    return parseModule(code) == \module("Example", {}, entity({annoTable("users")}, "User", {}));
 }
 
 test bool testShouldParseIndexesAnnotationForEntity()
@@ -18,9 +18,9 @@ test bool testShouldParseIndexesAnnotationForEntity()
     str code = "module Example;
                '@index(my_index, {name, email})
                '@index(second_index, {quantity, total})
-               'entity User {}";
+               'entity User { }";
 
-    Artifact expectedEntity = entity({index("my_index", {"name", "email"}), index("second_index", {"quantity", "total"})}, "User");
+    Declaration expectedEntity = entity({index("my_index", {"name", "email"}), index("second_index", {"quantity", "total"})}, "User", {});
 
     return parseModule(code) == \module("Example", {}, expectedEntity);
 }
@@ -31,14 +31,15 @@ test bool testShouldParseCompositeAnnotationForEntity()
                '@index(my_index, {name, email})
                '@index(second_index, {quantity, total})
                '@table(name=my_users_table)
-               'entity User {}";
+               'entity User { }";
 
-    Artifact expectedEntity = entity(
+    Declaration expectedEntity = entity(
         {
             index("my_index", {"name", "email"}),
             index("second_index", {"quantity", "total"}),
             annoTable("my_users_table")
-        }, "User");
+        }, "User", {});
 
     return parseModule(code) == \module("Example", {}, expectedEntity);
 }
+

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -9,7 +9,7 @@ test bool testShouldParseEmptyEntityWithName()
     str code = "module Example;
                'entity User {}";
 
-    return parseModule(code) == \module("Example", {}, entity({}, "User"));
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {}));
 }
 
 test bool testShouldParseEmptyEntityWithModuleImports()
@@ -21,13 +21,14 @@ test bool testShouldParseEmptyEntityWithModuleImports()
                'use Language entity from I18n;
                'entity User {}";
 
-   set[Import] expectedImports = {
+   set[Declaration] expectedImports = {
         importExternal("User", "entity", "Auth", "UserEntity"),
         importInternal("Money", "value"),
         importInternal("Money", "collection", "MoneySet"),
         importExternal("Language", "entity", "I18n")
    };
 
-    return parseModule(code) == \module("Example", expectedImports, entity({}, "User"));
+    return parseModule(code) == \module("Example", expectedImports, entity({}, "User", {}));
 }
+
 

--- a/src/Test/Parser/Entity/Values.rsc
+++ b/src/Test/Parser/Entity/Values.rsc
@@ -1,0 +1,49 @@
+module Test::Parser::Entity::Values
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool testShouldParseEntityWithValues()
+{
+    str code = "module Example;
+               'entity User {
+               '    value int id with {get};
+               '    value Date addedOn with {get, set};
+               '}";
+    set[Declaration] expectedValues = {
+        entityValue({}, "int", "id", {"get"}),
+        entityValue({}, "Date", "addedOn", {"get", "set"})
+    };
+
+    return parseModule(code) == \module("Example", {}, entity({}, "User", expectedValues));
+}
+
+test bool testShouldParseEntityWithValuesAndAnnotations()
+{
+    str code = "module Example;
+               'entity User {
+               '    @field(
+               '        key: primary,
+               '        sequence: true,
+               '        type: int,
+               '        size: 11,
+               '        column: id
+               '    )
+               '    value int id with {get};
+               '}";
+    set[Declaration] expectedValues = {
+        entityValue({
+            annoField({
+                annoPair("key", "primary"),
+                // TODO make it use booleans too
+                annoPair("sequence", "true"),
+                annoPair("type", "int"),
+                annoPair("size", "11"),
+                annoPair("column", "id")
+            })
+        }, "int", "id", {"get"})
+    };
+
+    return parseModule(code) == \module("Example", {}, entity({}, "User", expectedValues));
+}

--- a/src/Test/Parser/ModuleBasics.rsc
+++ b/src/Test/Parser/ModuleBasics.rsc
@@ -7,18 +7,18 @@ import Prelude;
 test bool testShouldParseModule()
 {
     str code = "module Example;";
-    
-    Module ast = parseModule(code);
-    
+
+    Declaration ast = parseModule(code);
+
     return ast == \module("Example", {});
 }
 
 test bool testShouldParseModuleWithUnderscoresInName()
 {
     str code = "module my_example_module;";
-    
-    Module ast = parseModule(code);
-    
+
+    Declaration ast = parseModule(code);
+
     return ast == \module("my_example_module", {});
 }
 
@@ -26,10 +26,10 @@ test bool testShouldNotParseTwoModuleDeclarations()
 {
     str code = "module my_example_module;
                'module this_should_throw_error;";
-             
+
     try parseModule(code);
     catch ParseError(x): return true;
-    
+
     return false;
 }
 
@@ -37,7 +37,7 @@ test bool testShouldParseModuleWithImportFromOtherModule()
 {
     str code = "module Example;
                'use User entity from Auth;";
-    
+
     return parseModule(code) == \module("Example", {importExternal("User", "entity", "Auth")});
 }
 
@@ -45,7 +45,7 @@ test bool testShouldParseModuleWithImportFromSameModule()
 {
     str code = "module Example;
                'use User entity;";
-    
+
     return parseModule(code) == \module("Example", {importInternal("User", "entity")});
 }
 
@@ -53,15 +53,15 @@ test bool testShouldParseModuleWithImportFromSameModuleWithAlias()
 {
     str code = "module Example;
                'use User entity as UserEntity;";
-    
+
     return parseModule(code) == \module("Example", {importInternal("User", "entity", "UserEntity")});
 }
 
 test bool testShouldParseModuleWithImportFromOtherModuleWithAlias()
 {
-    str code = "module Example; 
+    str code = "module Example;
                'use User entity from Auth as UserEntity;";
-    
+
     return parseModule(code) == \module("Example", {importExternal("User", "entity", "Auth", "UserEntity")});
 }
 
@@ -72,13 +72,13 @@ test bool testShouldParseModuleWithCompositeImports()
                'use Money value;
                'use Money collection as MoneySet;
                'use Language entity from I18n;";
-               
-   set[Import] expectedImports = {
+
+   set[Declaration] expectedImports = {
         importExternal("User", "entity", "Auth", "UserEntity"),
         importInternal("Money", "value"),
         importInternal("Money", "collection", "MoneySet"),
         importExternal("Language", "entity", "I18n")
    };
-   
+
    return parseModule(code) == \module("Example", expectedImports);
 }


### PR DESCRIPTION
#### Description

Enables values in entities
#### Syntax
1. `value`_`Value_Type Value_Name` where _Value_Type_ and _Value_Name_ are identifiers
2. `value`_`Value_Type Value_Name`_`with {get, set}` Where _get_ and _set_ are optional value permission properties
#### Examples

```
module Example;
entity User {
    @field(
        key: primary,
        sequence: true,
        type: int,
        size: 11,
        column: id
    )
    value int id with {get};
}
```
