### PR TITLE
Added grammar for entity relations

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -7,10 +7,12 @@ data Declaration = \module(str name, set[Declaration] imports)
                  | importExternal(str target, str \artifactType, str \module)
                  | importExternal(str target, str \artifactType, str \module, str \alias)
                  // artifacts
-                 | entity(set[Declaration] annotations, str name, set[Declaration] values)
-                 | entity(str name, set[Declaration] values)
+                 | entity(set[Declaration] annotations, str name, set[Declaration] declarations)
+                 | entity(str name, set[Declaration] declarations)
                  | entityValue(set[Declaration] annotations, str \type, str name)
                  | entityValue(set[Declaration] annotations, str \type, str name, set[str] valueProperties)
+                 | relation(str local, str foreign, str entity, str \alias)
+                 | relation(str local, str foreign, str entity, str \alias, set[str] relProperties)
                  // annotations
                  | annoTable(str name)
                  | annoField(set[Expression] pairs)
@@ -18,3 +20,4 @@ data Declaration = \module(str name, set[Declaration] imports)
                  ;
 
 data Expression = annoPair(str key, str \value);
+

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -18,8 +18,14 @@ syntax Imports = importInternal: "use" Identifier target ImportArtifactType arti
 
 // Artifacts grammar
 
-syntax Artifact = entity: EntityAnno* annotations "entity" Identifier name "{" EntityValue* values "}"
+syntax Artifact = entity: EntityAnno* annotations "entity" Identifier name "{" EntityDeclarations* declarations "}"
                 ;
+
+syntax EntityDeclarations = EntityValue | EntityRelation;
+
+syntax EntityRelation = relation: "relation" RelationDir local ":" RelationDir foreign Identifier entity "as" Identifier alias ";"
+                      | relation: "relation" RelationDir local ":" RelationDir foreign Identifier entity "as" Identifier alias "with" "{" {RelProperties ","}* "}" ";"
+                      ;
 
 syntax EntityValue = entityValue: EntityValueAnno* annotations "value" Identifier type Identifier name ";"
                    | entityValue: EntityValueAnno* annotations "value" Identifier type Identifier name "with" "{" {ValueProperties ","}* "}" ";"
@@ -39,7 +45,9 @@ lexical LAYOUT = [\t-\n\r\ ];
 lexical Name = [a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
 lexical Identifier =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_];
 lexical ImportArtifactType = "entity" | "value" | "repository" | "collection" | "util" | "service";
-lexical ValueProperties = "get" | "set" | "add" | "clear" ;
+lexical ValueProperties = "get" | "set" ;
+lexical RelationDir = "one" | "many" ;
+lexical RelProperties = "get" | "set" | "add" | "reset" | "clear" ;
 
 lexical UnicodeEscape
       = utf16: "\\" [u] [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f] [0-9 A-F a-f]
@@ -56,4 +64,5 @@ lexical StringCharacter
 
 
 lexical StringConstant = "\"" StringCharacter* chars "\"" ;
+
 

--- a/src/Test/All.rsc
+++ b/src/Test/All.rsc
@@ -1,7 +1,11 @@
 module Test::All
 
+// general module tests
 extend Test::Parser::ModuleBasics;
+
+// entities
 extend Test::Parser::Entity::Basics;
 extend Test::Parser::Entity::Annotations;
 extend Test::Parser::Entity::Values;
+extend Test::Parser::Entity::Relations;
 

--- a/src/Test/Parser/Entity/Relations.rsc
+++ b/src/Test/Parser/Entity/Relations.rsc
@@ -1,0 +1,19 @@
+module Test::Parser::Entity::Relations
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool testShouldParseEntityRelations()
+{
+    str code = "module Example;
+               'entity User {
+               '    relation one:one Language as userLanguage;
+               '    relation one:many User as userFriends with {add, set, get, clear};
+               '}";
+
+   return parseModule(code) == \module("Example", {}, entity({}, "User", {
+       relation("one", "one", "Language", "userLanguage"),
+       relation("one", "many", "User", "userFriends", {"add", "set", "get", "clear"})
+   }));
+}

--- a/src/Tests.rsc
+++ b/src/Tests.rsc
@@ -6,6 +6,8 @@ public int main(list[str] args) {
    list[bool] results = [];
 
 
+   results += testShouldParseEntityRelations();
+
    results += testShouldParseEntityWithValues();
 
    results += testShouldParseEntityWithValuesAndAnnotations();


### PR DESCRIPTION
#### Description

Added grammar for entity relations
#### Syntax
1. `relation one:one`_`Foreign_Entity`_`as`_`Entity_Alias`_ where one:one can be also one:many many:one. _Foreign_Entity_ and _Entity_Alias_ are identifiers
2. `relation one:one`_`Foreign_Entity`_`as`_`Entity_Alias`_`with {set, get, add, clear}`
#### Example

```
module Example;

entity User {
    relation one:one Language as userLanguage;
    relation one:many User as userFriends with {add, set, get, clear};
}
```
