### PR TITLE
Adjusted naming constraints in grammar + tested

### DIFF
--- a/src/BuildTests.rsc
+++ b/src/BuildTests.rsc
@@ -38,10 +38,16 @@ public void main(list[str] args)
                         '
                         'public void main(list[str] args) {
                         '   list[bool] results = [];
-
+                        '
                         '<for (function <- functions) {>
-                        '   results += <function>();
-                        '   print(\".\");<}>
+                        '   try {
+                        '       results += <function>();
+                        '       print(\".\");
+                        '   } catch e: {
+                        '       throw \"Test <function> failed\";
+                        '       return;
+                        '   }
+                        '<}>
                         '   println(\"OK\");
                         '}
                         '";

--- a/src/Parser/ParseCode.rsc
+++ b/src/Parser/ParseCode.rsc
@@ -2,6 +2,8 @@ module Parser::ParseCode
 
 import Syntax::Concrete::Grammar;
 import ParseTree;
+import String;
+import IO;
 
-public Tree parseCode(str code) = parse(#Module, code);
-public Tree parseFile(loc file) = parse(#Module, file);
+public Tree parseCode(str code) = parse(#Module, trim(code));
+public Tree parseFile(loc file) = parseCode(readFile(file));

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -76,4 +76,3 @@ data Type
     | typedArray(Type \type)
     | artifactType(str name)
     ;
-

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -7,21 +7,21 @@ extend Syntax::Concrete::Grammar::Lexical;
 // Start grammar
 
 start syntax Module
-   = \module: ^"module" Identifier name ";" Imports* imports
-   | \module: ^"module" Identifier name ";" Imports* imports Artifact mainArtifact
+   = \module: ^"module" Name name ";" Imports* imports
+   | \module: ^"module" Name name ";" Imports* imports Artifact mainArtifact
    ;
 
 syntax Imports
-    = importInternal: "use" Identifier target ImportArtifactType artifactType ";"
-    | importInternal: "use" Identifier target ImportArtifactType artifactType "as" Identifier alias ";"
-    | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module ";"
-    | importExternal: "use" Identifier target ImportArtifactType artifactType "from" Identifier module "as" Identifier alias ";"
+    = importInternal: "use" ArtifactName target ImportArtifactType artifactType ";"
+    | importInternal: "use" ArtifactName target ImportArtifactType artifactType "as" ArtifactName alias ";"
+    | importExternal: "use" ArtifactName target ImportArtifactType artifactType "from" Name module ";"
+    | importExternal: "use" ArtifactName target ImportArtifactType artifactType "from" Name module "as" ArtifactName alias ";"
     ;
 
 // Artifacts grammar
 
 syntax Artifact
-    = entity: EntityAnno* annotations "entity" Identifier name "{" EntityDeclarations* declarations "}"
+    = entity: EntityAnno* annotations "entity" ArtifactName name "{" EntityDeclarations* declarations "}"
     ;
 
 syntax EntityDeclarations
@@ -31,18 +31,18 @@ syntax EntityDeclarations
     ;
 
 syntax EntityRelation
-    = relation: "relation" RelationDir local ":" RelationDir foreign Identifier entity "as" Identifier alias ";"
-    | relation: "relation" RelationDir local ":" RelationDir foreign Identifier entity "as" Identifier alias "with" "{" {RelProperties ","}* "}" ";"
+    = relation: "relation" RelationDir local ":" RelationDir foreign ArtifactName entity "as" MemberName alias ";"
+    | relation: "relation" RelationDir local ":" RelationDir foreign ArtifactName entity "as" MemberName alias "with" "{" {RelProperties ","}* "}" ";"
     ;
 
 syntax EntityValue
-    = entityValue: EntityValueAnno* annotations "value" Type type Identifier name ";"
-    | entityValue: EntityValueAnno* annotations "value" Type type Identifier name "with" "{" {ValueProperties ","}* "}" ";"
+    = entityValue: EntityValueAnno* annotations "value" Type type MemberName name ";"
+    | entityValue: EntityValueAnno* annotations "value" Type type MemberName name "with" "{" {ValueProperties ","}* "}" ";"
     ;
 
 syntax EntityAnno
     = annoTable: "@table(" "name=" Name name ")"
-    | index: "@index(" Identifier name "," "{" {Identifier ","}* columns "}" ")"
+    | index: "@index(" Name name "," "{" {Name ","}* columns "}" ")"
     ;
 
 syntax EntityValueAnno = annoField: "@field(" {AnnotationFieldKeyPair ","}* pairs ")";
@@ -53,15 +53,15 @@ syntax AnnotationFieldKeyPair
     | annoPair: AnnotationFieldTypeIndex key ":" DatabaseType value
     | annoPair: AnnotationFieldSizeIndex key ":" DecimalIntegerLiteral value
     | annoPair: AnnotationFieldScaleIndex key ":" DecimalIntegerLiteral value
-    | annoPair: AnnotationFieldColumnIndex key ":" Identifier value
+    | annoPair: AnnotationFieldColumnIndex key ":" Name value
     ;
 
 // TODO replace Name with lower-case starting alphabetical-chars-only non-terminal
 syntax Method
-    = method: Modifier modifier Type returnType Name name "(" {Parameter ","}* parameters ")" "=" Expression expr ";"
-    | method: Modifier modifier Type returnType Name name "(" {Parameter ","}* parameters ")" "=" Expression expr "when" Expression when ";"
-    | method: Modifier modifier Type returnType Name name "(" {Parameter ","}* parameters ")" "{" Statement* body "}"
-    | method: Modifier modifier Type returnType Name name "(" {Parameter ","}* parameters ")" "{" Statement* body "}" "when" Expression when ";"
+    = method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "=" Expression expr ";"
+    | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "=" Expression expr "when" Expression when ";"
+    | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "{" Statement* body "}"
+    | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "{" Statement* body "}" "when" Expression when ";"
     ;
 
 syntax Modifier
@@ -90,20 +90,20 @@ syntax Type
     | \bool: "boolean"
     | voidValue: "void"
     | typedArray: Type type "[]"
-    > artifactType: Name name
+    > artifactType: ArtifactName name
     ;
 
 syntax Parameter
-    = parameter: Type paramType AlphaIdentifier name
-    | parameter: Type paramType AlphaIdentifier name "=" ParameterDefaultValue defaultValue
+    = parameter: Type paramType MemberName name
+    | parameter: Type paramType MemberName name "=" ParameterDefaultValue defaultValue
     ;
 
 syntax ParameterDefaultValue
-    = stringLiteral: "\"" StringCharacter* string "\""
-    | intLiteral: DecimalIntegerLiteral number
-    | floatLiteral: DeciFloatNumeral number
-    | booleanLiteral: Boolean boolean
-    | array: "[" {ParameterDefaultValue ","}* items "]" array
+    = stringLiteral     : "\"" StringCharacter* string "\""
+    | intLiteral        : DecimalIntegerLiteral number
+    | floatLiteral      : DeciFloatNumeral number
+    | booleanLiteral    : Boolean boolean
+    | array             : "[" {ParameterDefaultValue ","}* items "]" array
     ;
 
 syntax Statement
@@ -119,7 +119,7 @@ syntax Expression
     | intLiteral        : DecimalIntegerLiteral number
     | floatLiteral      : DeciFloatNumeral number
     | booleanLiteral    : Boolean boolean
-    | variable          : Name varName
+    | variable          : MemberName varName
     > left ( product: Expression lhs "*" () !>> "*" Expression rhs
            | remainder: Expression lhs "%" Expression rhs
            | division: Expression lhs "/" Expression rhs

--- a/src/Syntax/Concrete/Grammar/Lexical.rsc
+++ b/src/Syntax/Concrete/Grammar/Lexical.rsc
@@ -1,7 +1,25 @@
 module Syntax::Concrete::Grammar::Lexical
 
+extend Syntax::Concrete::Grammar::Keywords;
+
+lexical ArtifactName
+    =  ([A-Z] !<< [A-Z] [0-9 A-Z a-z]* !>> [0-9 A-Z a-z]) \ GlagolPreserved
+    ;
+
+lexical MemberName
+    =  ([a-z] !<< [a-z] [0-9 A-Z a-z]* !>> [0-9 A-Z a-z]) \ GlagolPreserved
+    ;
+
 lexical Identifier
-    =  [a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_] \ GlagolPreserved;
+    =  ([a-zA-Z][a-zA-Z0-9_]* !>> [a-zA-Z0-9_]) \ GlagolPreserved;
+
+lexical AlphaIdentifier
+    =  ([A-Z a-z] !<< [A-Z a-z] [0-9 A-Z a-z]* !>> [0-9 A-Z a-z]) \ GlagolPreserved
+    ;
+
+lexical Name
+    =  ([A-Z a-z _] !<< [A-Z _ a-z] [0-9 A-Z _ a-z]* !>> [0-9 A-Z _ a-z]) \ GlagolPreserved
+    ;
 
 lexical ImportArtifactType
     = "entity" | "value" | "repository" | "collection" | "util" | "service";
@@ -50,14 +68,6 @@ lexical DeciFloatNumeral
     | [0-9] !<< [0-9]+ >> [D F d f]
     | [0-9] !<< [0-9]+ "." [0-9]* !>> [0-9] DeciFloatExponentPart?
     | [0-9] !<< "." [0-9]+ !>> [0-9] DeciFloatExponentPart?
-    ;
-
-lexical AlphaIdentifier
-    =  ([A-Z a-z] !<< [A-Z a-z] [0-9 A-Z a-z]* !>> [0-9 A-Z a-z]) \ GlagolPreserved
-    ;
-
-lexical Name
-    =  ([A-Z a-z _] !<< [A-Z _ a-z] [0-9 A-Z _ a-z]* !>> [0-9 A-Z _ a-z]) \ GlagolPreserved
     ;
 
 lexical AnnotationFieldKeyIndex

--- a/src/Test/Parser/Entity/Annotations.rsc
+++ b/src/Test/Parser/Entity/Annotations.rsc
@@ -42,4 +42,3 @@ test bool testShouldParseCompositeAnnotationForEntity()
 
     return parseModule(code) == \module("Example", {}, expectedEntity);
 }
-

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -30,5 +30,3 @@ test bool testShouldParseEmptyEntityWithModuleImports()
 
     return parseModule(code) == \module("Example", expectedImports, entity({}, "User", {}));
 }
-
-

--- a/src/Test/Parser/Entity/NamingConstraints.rsc
+++ b/src/Test/Parser/Entity/NamingConstraints.rsc
@@ -1,0 +1,284 @@
+module Test::Parser::Entity::NamingConstraints
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool moduleNameCannotUsePreservedKeywords()
+{
+    bool success = false;
+    
+    str failCode 
+        = "module true;";
+    
+    try parseModule(failCode);
+    catch e: success = true;
+    
+    str successCode 
+        = "module ThisIsOk_IGuess;";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool moduleArtifactImportsShouldStartWithCapital()
+{
+    bool success = false;
+    
+    str failCode 
+        = "module Example;
+          'use user entity from I18n;";
+    
+    try parseModule(failCode);
+    catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'use User entity from I18n;
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool moduleArtifactImportsShouldNotContainUnderscores()
+{
+    bool success = false;
+    
+    str failCode 
+        = "module Example;
+          'use User_Entity entity from I18n;";
+    
+    try parseModule(failCode);
+    catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'use UserEntity entity from I18n;
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool artifactsShouldBeAlphabeticalStartingWithCapital()
+{
+    bool success = false;
+    
+    str failCodeLowerCaseFirst
+        = "module Example;
+          'entity user {
+          '}
+          '";
+    
+    try parseModule(failCodeLowerCaseFirst);
+    catch e: success = true;
+    
+    str failCodeUnderscore 
+        = "module Example;
+          'entity Underscored_Entity {
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscore);
+        success = false;
+    } catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'entity UserExampleEntity {
+          '}
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool entityValuesShouldStartWithLowerCaseAndBeAlphaCharsOnly()
+{
+    bool success = false;
+    
+    str failCodeUpperCaseFirst
+        = "module Example;
+          'entity User {
+          '    value int MyValue with {get, set};
+          '}
+          '";
+    
+    try parseModule(failCodeUpperCaseFirst);
+    catch e: success = true;
+    
+    str failCodeUnderscore 
+        = "module Example;
+          'entity User {
+          '    value int my_Value with {get, set};
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscore);
+        success = false;
+    } catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'entity User {
+          '    value int myValue with {get, set};
+          '}
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool entityRelationsShouldStartWithLowerCaseAndBeAlphaCharsOnly()
+{
+    bool success = false;
+    
+    str failCodeLowerCaseFirst
+        = "module Example;
+          'entity User {
+          '    relation one:one language as userLanguage;
+          '}
+          '";
+    
+    try parseModule(failCodeLowerCaseFirst);
+    catch e: success = true;
+    
+    str failCodeUpperCaseAlias 
+        = "module Example;
+          'entity User {
+          '    relation one:one Language as UserLanguage;
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUpperCaseAlias);
+        success = false;
+    } catch e: success = true;
+    
+    str failCodeUnderscore
+        = "module Example;
+          'entity User {
+          '    relation one:one User_Language as userLanguage;
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscore);
+        success = false;
+    } catch e: success = true;
+    
+    str failCodeUnderscoreAlias 
+        = "module Example;
+          'entity User {
+          '    relation one:one Language as user_language;
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscoreAlias);
+        success = false;
+    } catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'entity User {
+          '    relation one:one Language as userLanguage;
+          '}
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool methodsShouldStartWithLowerCaseAndBeAlphaCharsOnly()
+{
+    bool success = false;
+    
+    str failCodeUpperCaseFirst
+        = "module Example;
+          'entity User {
+          '    int BadFunctionName() = 4;
+          '}
+          '";
+    
+    try parseModule(failCodeUpperCaseFirst);
+    catch e: success = true;
+    
+    str failCodeUnderscore 
+        = "module Example;
+          'entity User {
+          '    string bad_FunctionName() = \"bad\";
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscore);
+        success = false;
+    } catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'entity User {
+          '    string goodFunctionName() = \"correct\";
+          '}
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}
+
+test bool parametersShouldStartWithLowerCaseAndBeAlphaCharsOnly()
+{
+    bool success = false;
+    
+    str failCodeUpperCaseFirst
+        = "module Example;
+          'entity User {
+          '    int badParameters(int BadExample) = 2;
+          '}
+          '";
+    
+    try parseModule(failCodeUpperCaseFirst);
+    catch e: success = true;
+    
+    str failCodeUnderscore 
+        = "module Example;
+          'entity User {
+          '    int badParameters(int bad_Example) = 2;
+          '}
+          '";
+    
+    try {
+        parseModule(failCodeUnderscore);
+        success = false;
+    } catch e: success = true;
+    
+    str successCode 
+        = "module Example;
+          'entity User {
+          '    bool goodParameters(int goodExample) = true;
+          '}
+          '";
+    
+    try parseModule(successCode);
+    catch e: success = false;
+    
+    return success;
+}


### PR DESCRIPTION
#### Description

Added naming constraints for modules, artifacts, values, relations, parameters and variables.
#### Constraints
##### Modules

Modules are with the least restricted naming. They can include alphabetical characters, numbers and underscores. There are no restrictions for the first char.
##### Artifacts

Artifacts should always be defined with a capital first alphabetical character, and only alpha-chars are allowed.
##### Relations, values, variables, parameters

They all should start with a lower-case alphabetical char and can contain only alphabetical chars.
