### PR TITLE
Added grammar for artifact constructors

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -23,13 +23,17 @@ data Declaration
     | method(Modifier modifier, Type returnType, str name, set[Declaration] parameters, Expression expr, Expression when)
     | method(Modifier modifier, Type returnType, str name, set[Declaration] parameters, list[Statement] body)
     | method(Modifier modifier, Type returnType, str name, set[Declaration] parameters, list[Statement] body, Expression when)
+    | constructor(set[Declaration] parameters, Statement constructorBody, Expression when, Declaration conditionalThrow)
     | parameter(Type paramType, str name)
     | parameter(Type paramType, str name, Expression defaultValue)
+    | conditionalThrow(str exceptionName, list[Expression] arguments, Expression condition)
+    | emptyDeclaration()
     ;
 
 data Statement
     = methodCall()
     | block(list[Statement] stmts)
+    | methodBody(list[Statement] stmts)
     | expression(Expression expr)
     | empty()
     ;
@@ -59,6 +63,8 @@ data Expression
     | or(Expression lhs, Expression rhs)
     | ifThenElse(Expression condition, Expression ifThen, Expression \else)
     | array(list[Expression] values)
+    | none()
+    | expr(Expression expr)
 	;
 
 data Modifier

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -27,6 +27,7 @@ syntax Artifact
 syntax EntityDeclarations
     = EntityValue
     | EntityRelation
+    | Constructor
     | Method
     ;
 
@@ -62,6 +63,25 @@ syntax Method
     | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "=" Expression expr "when" Expression when ";"
     | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "{" Statement* body "}"
     | method: Modifier modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "{" Statement* body "}" "when" Expression when ";"
+    ;
+
+syntax Constructor
+    = constructor: "constructor" "(" {Parameter ","}* parameters ")" MethodBody body When when ConditionalThrow throw ";"
+    ;
+
+syntax MethodBody
+    = methodBody: "{" Statement* body "}"
+    | empty: ()
+    ;
+
+syntax When
+    = "when" Expression expr
+    | none: ()
+    ; 
+
+syntax ConditionalThrow
+    = conditionalThrow: "throws" ArtifactName exceptionName "(" {ParameterDefaultValue ","}* arguments ")" "if" Expression condition
+    | emptyDeclaration: ()
     ;
 
 syntax Modifier

--- a/src/Syntax/Concrete/Grammar/Keywords.rsc
+++ b/src/Syntax/Concrete/Grammar/Keywords.rsc
@@ -20,4 +20,7 @@ keyword GlagolPreserved
     | "false"
     | "when"
     | "void"
+    | "constructor"
+    | "throws"
+    | "if"
     ;

--- a/src/Test/Parser/Entity/Constructors.rsc
+++ b/src/Test/Parser/Entity/Constructors.rsc
@@ -1,0 +1,30 @@
+module Test::Parser::Entity::Constructors
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool shouldParseConstructWithAndWithoutWhenExpr()
+{
+    str code 
+        = "module Example;
+          'entity User {
+          '    constructor(int param) {
+          '        \"some expression\";
+          '        true;
+          '    }
+          '    when param == 1 
+          '    throws MyException(\"Generic exception message\") if param == 2;
+          '}
+          '";
+    
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        constructor({parameter(integer(), "param")}, methodBody([
+                expression(stringLiteral("some expression")),
+                expression(booleanLiteral("true"))
+            ]), 
+            equals(variable("param"), intLiteral(1)), 
+            conditionalThrow("MyException", [stringLiteral("Generic exception message")], equals(variable("param"), intLiteral(2)))
+        )
+    }));
+}


### PR DESCRIPTION
#### Description

Adds grammar for constructors
#### Syntax
- `constructor(`_`Parameters*`_`) {`_`MethodBody`_`} when`_`Expression`_`throws`_`Exception`_`if`_`Expression`_`;`

Where _`Exception`_ is name of an exception type of artifact.

The `{`_`MethodBody`_`}`, `when`_`Expression(Arguments*)`_ and `throws`_`Exception`_`if`_`Expression`_
are optional
#### Easy exception throwing

The `throws`_`Exception`_`if`_`Expression`_ declaration instruct the compiler to throw exception on a specific condition when the constructor is executed.
