### PR TITLE
Added if-then and if-then-else statements

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -32,6 +32,8 @@ data Statement
     | block(list[Statement] stmts)
     | methodBody(list[Statement] stmts)
     | expression(Expression expr)
+    | ifThen(Expression condition, Statement then)
+    | ifThenElse(Expression condition, Statement then, Statement \else)
     | empty()
     ;
 

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -11,6 +11,7 @@ start syntax Module
    | \module: ^"module" Name name ";" Imports* imports Artifact mainArtifact
    ;
 
+// TODO improve this grammar, always include the alias (use empty for default)
 syntax Imports
     = importInternal: "use" ArtifactName target ImportArtifactType artifactType ";"
     | importInternal: "use" ArtifactName target ImportArtifactType artifactType "as" ArtifactName alias ";"
@@ -136,6 +137,9 @@ syntax DefaultValue
 syntax Statement
     = expression: Expression expression ";"
     | empty: ";"
+    | block: "{" Statement* statements "}"
+    | ifThen: "if" "(" Expression condition ")" Statement then () !>> "else"
+    | ifThenElse: "if" "(" Expression condition ")" Statement then "else" Statement else
     ;
 
 syntax Expression

--- a/src/Test/Parser/Statements/Ifs.rsc
+++ b/src/Test/Parser/Statements/Ifs.rsc
@@ -1,0 +1,103 @@
+module Test::Parser::Statements::Ifs
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool shoudlParseIfThenStmt()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example() {
+               '        if (a \> b) true;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {}, [
+            ifThen(greaterThan(variable("a"), variable("b")), expression(booleanLiteral("true")))
+        ], none())
+    }));
+}
+
+test bool shouldParseIfThenElseStmt()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example() {
+               '        if (a \> b) true; 
+               '        else        false;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {}, [
+            ifThenElse(greaterThan(variable("a"), variable("b")), expression(booleanLiteral("true")), expression(booleanLiteral("false")))
+        ], none())
+    }));
+}
+
+
+test bool shoudlParseIfThenStmtWithBlock()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example() {
+               '        if (a \> b) {
+               '            true;
+               '        }
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {}, [
+            ifThen(greaterThan(variable("a"), variable("b")), block([expression(booleanLiteral("true"))]))
+        ], none())
+    }));
+}
+
+test bool shouldParseIfThenElseStmtWithBlocks()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example() {
+               '        if (a \> b) {
+               '            true; 
+               '        } else {
+               '            false;
+               '        }
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {}, [
+            ifThenElse(greaterThan(variable("a"), variable("b")), 
+                block([expression(booleanLiteral("true"))]), 
+                block([expression(booleanLiteral("false"))])
+            )
+        ], none())
+    }));
+}
+
+test bool shouldParseIfThenElseIfStmt()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example() {
+               '        if (a \> b) {
+               '            true; 
+               '        } else if (a == b) {
+               '            false;
+               '        }
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {}, [
+            ifThenElse(greaterThan(variable("a"), variable("b")), 
+                block([expression(booleanLiteral("true"))]), 
+                ifThen(equals(variable("a"), variable("b")), block([expression(booleanLiteral("false"))]))
+            )
+        ], none())
+    }));
+}


### PR DESCRIPTION
#### Description

Adds conditional `if` and `if..else` statements to the grammar
#### Syntax
- `if (`_`Expression`_`)`_`Statement`_
- `if (`_`Expression`_`)`_`Statement`_`else`_`Statement`_

Since `if` is a statement itself, it can be used after the `else` keyword to create else-if statements 
