### PR TITLE
Assignment statement

### DIFF
--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -33,6 +33,7 @@ data Statement
     | expression(Expression expr)
     | ifThen(Expression condition, Statement then)
     | ifThenElse(Expression condition, Statement then, Statement \else)
+    | assign(set[Expression] assignables, AssignOperator operator, Statement \value)
     | empty()
     ;
 
@@ -43,6 +44,7 @@ data Expression
     | booleanLiteral(str boolValue)
     | stringLiteral(str stringValue)
     | variable(str name)
+    | arrayAccess(Expression variable, Expression arrayIndexKey)
     | when(Expression expr)
     | \bracket(Expression expr)
     | product(Expression lhs, Expression rhs)
@@ -70,6 +72,14 @@ data Expression
 data Modifier
     = \private()
     | \public()
+    ;
+
+data AssignOperator
+    = defaultAssign()
+    | divisionAssign()
+    | productAssign()
+    | subtractionAssign()
+    | additionAssign()
     ;
 
 data Type

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -155,6 +155,20 @@ syntax Statement
     | block: "{" Statement* statements "}"
     | ifThen: "if" "(" Expression condition ")" Statement then () !>> "else"
     | ifThenElse: "if" "(" Expression condition ")" Statement then "else" Statement else
+    | assign: {Assignable ","}+ assignables AssignOperator operator Statement value !empty!block!ifThen!ifThenElse
+    ;
+
+syntax Assignable
+    = variable    : MemberName varName
+    | arrayAccess : Assignable variable "[" Expression key "]"
+    ;
+
+syntax AssignOperator
+    = divisionAssign    : "/=" 
+    | productAssign     : "*=" 
+    | subtractionAssign : "-=" 
+    | defaultAssign     : "=" 
+    | additionAssign    : "+=" 
     ;
 
 syntax Expression

--- a/src/Test/Parser/Statements/Assignment.rsc
+++ b/src/Test/Parser/Statements/Assignment.rsc
@@ -1,0 +1,98 @@
+module Test::Parser::Statements::Assignment
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+import Prelude;
+
+test bool shoudlParseAssignmentStmt()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example(int a) {
+               '        a = 5;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {parameter(integer(), "a", none())}, [
+            assign({variable("a")}, defaultAssign(), expression(intLiteral(5)))
+        ], none())
+    }));
+}
+
+test bool shouldParseAssignmentStmtUsingArrays()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example(int[] a, int[][] b) {
+               '        a[0]    = 5;
+               '        b[0][1] = 4;
+               '    }
+               '}";
+    
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {
+                parameter(typedArray(integer()), "a", none()), 
+                parameter(typedArray(typedArray(integer())), "b", none())
+            }, [
+            assign({arrayAccess(variable("a"), intLiteral(0))}, defaultAssign(), expression(intLiteral(5))),
+            assign({arrayAccess(arrayAccess(variable("b"), intLiteral(0)), intLiteral(1))}, defaultAssign(), expression(intLiteral(4)))
+        ], none())
+    }));
+}
+
+test bool shoudlParseAssignmentStmtUsingDiffAssignOperators()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example(int a = 1) {
+               '        a += 5;
+               '        a *= 2;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {parameter(integer(), "a", defaultValue(intLiteral(1)))}, [
+            assign({variable("a")}, additionAssign(), expression(intLiteral(5))),
+            assign({variable("a")}, productAssign(), expression(intLiteral(2)))
+        ], none())
+    }));
+}
+
+test bool shouldParseMultiAssign()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example(int a, int b) {
+               '        a, b = 4;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {
+                parameter(integer(), "a", none()),
+                parameter(integer(), "b", none())
+            }, [
+            assign({variable("a"), variable("b")}, defaultAssign(), expression(intLiteral(4)))
+        ], none())
+    }));
+}
+
+test bool shouldParseNestedAssignments()
+{
+    str code = "module Example;
+               'entity User {
+               '    void example(int a, int b) {
+               '        a = b = 4;
+               '    }
+               '}";
+               
+    return parseModule(code) == \module("Example", {}, entity({}, "User", {
+        \method(\public(), voidValue(), "example", {
+                parameter(integer(), "a", none()),
+                parameter(integer(), "b", none())
+            }, [
+            assign({variable("a")}, defaultAssign(), assign({variable("b")}, defaultAssign(), expression(intLiteral(4))))
+        ], none())
+    }));
+}


### PR DESCRIPTION
#### Description

Added support for assignment operators.
#### Syntax
1. _`Assignable`_<sub>`1`</sub>_`, Assignable`_<sub>`2`</sub>_`, ... Assignable`_<sub>`n`</sub>_`Operator Statement`_

Where _`Assignable`_ is either a `variable` or an array access (_`array[index]`_). 
_`Operator`_ is one of the following assignment operators: `=`, `+=`, `-=`, `*=`, `/=`
#### Examples

```
module Example;
entity User {
    void example(int a, int[] b) {
        a, b[0] = 5;
        b[1] = a = 6;
    }
}
```
