### PR TITLE
Declration statements

### DIFF
--- a/src/Parser/Converter/Statement.rsc
+++ b/src/Parser/Converter/Statement.rsc
@@ -5,6 +5,7 @@ import Syntax::Concrete::Grammar;
 import Parser::Converter::Expression;
 import Parser::Converter::Assignable;
 import Parser::Converter::AssignOperator;
+import Parser::Converter::Type;
 
 public Statement convertStmt((Statement) `<Expression expr>;`) = expression(convertExpression(expr));
 public Statement convertStmt((Statement) `;`) = emptyStmt();
@@ -20,3 +21,7 @@ public Statement convertStmt((Statement) `<Assignable assignable><AssignOperator
     = assign(convertAssignable(assignable), convertAssignOperator(operator), convertStmt(val));
 
 public Statement convertStmt((Statement) `return <Expression expr>;`) = \return(convertExpression(expr));
+
+public Statement convertStmt((Statement) `<Type t> <MemberName varName>;`) = declare(convertType(t), variable("<varName>"));
+public Statement convertStmt((Statement) `<Type t> <MemberName varName>=<Expression defValue>;`) 
+    = declare(convertType(t), variable("<varName>"), convertExpression(defValue));

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -97,6 +97,8 @@ data Statement
     | assign(Expression assignable, AssignOperator operator, Statement \value)
     | emptyStmt()
     | \return(Expression expr)
+    | declare(Type varType, Expression varName)
+    | declare(Type varType, Expression varName, Expression defaultValue)
     ;
 
 data AssignOperator

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -142,7 +142,8 @@ syntax Statement
     | ifThenElse: "if" "(" Expression condition ")" Statement then "else" Statement else
     | assign: Assignable assignable AssignOperator operator Statement value !empty!block!ifThen!ifThenElse
     | non-assoc  (
-        \return: "return" Expression expr ";"
+            \return: "return" Expression expr ";"
+        |   declare: Type type MemberName varName ("=" Expression expr)? ";"
     )
     ;   
 

--- a/src/Test/Parser/Entity/Annotations.rsc
+++ b/src/Test/Parser/Entity/Annotations.rsc
@@ -2,7 +2,6 @@ module Test::Parser::Entity::Annotations
 
 import Parser::ParseAST;
 import Syntax::Abstract::AST;
-import IO;
 
 test bool testShouldParseTableNameAnnotationForEntity()
 {

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -2,7 +2,6 @@ module Test::Parser::Entity::Basics
 
 import Parser::ParseAST;
 import Syntax::Abstract::AST;
-import IO;
 
 test bool entityDeclaration() {
     str code 

--- a/src/Test/Parser/ModuleBasics.rsc
+++ b/src/Test/Parser/ModuleBasics.rsc
@@ -2,7 +2,6 @@ module Test::Parser::ModuleBasics
 
 import Parser::ParseAST;
 import Syntax::Abstract::AST;
-import IO;
 
 test bool moduleDeclaration() {
     str code = "module Testing;";

--- a/src/Test/Parser/Statements.rsc
+++ b/src/Test/Parser/Statements.rsc
@@ -1,0 +1,63 @@
+module Test::Parser::Statements
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+
+test bool testDeclarationsWithPrimitiveTypes() {
+    str code
+        = "module Example;
+        'entity User {
+        '   User() {
+        '       float myVariable = 5.4;
+        '       int yourVariable = 23;
+        '       string myString = \"hello world\";
+        '       boolean withExpr = myVariable \> yourVariable;
+        '   }
+        '}";
+        
+    return parseModule(code) == \module("Example", {}, entity("User", {
+        constructor([], [
+            declare(float(), variable("myVariable"), floatLiteral(5.4)),
+            declare(integer(), variable("yourVariable"), intLiteral(23)),
+            declare(string(), variable("myString"), strLiteral("hello world")),
+            declare(boolean(), variable("withExpr"), greaterThan(variable("myVariable"), variable("yourVariable")))
+        ])
+    }));
+}
+
+test bool testDeclarationsWithoutDefaultValue() {
+    str code
+        = "module Example;
+        'entity User {
+        '   User() {
+        '       float myVariable;
+        '       int yourVariable;
+        '       
+        '       yourVariable = yourVariable + 5;
+        '   }
+        '}";
+        
+    return parseModule(code) == \module("Example", {}, entity("User", {
+        constructor([], [
+            declare(float(), variable("myVariable")),
+            declare(integer(), variable("yourVariable")),
+            assign(variable("yourVariable"), defaultAssign(), expression(addition(variable("yourVariable"), intLiteral(5))))
+        ])
+    }));
+}
+
+test bool testDeclarationsWithCustomTypes() {
+    str code
+        = "module Example;
+        'entity User {
+        '   User() {
+        '       DateTime myDate;
+        '   }
+        '}";
+        
+    return parseModule(code) == \module("Example", {}, entity("User", {
+        constructor([], [
+            declare(artifactType("DateTime"), variable("myDate"))
+        ])
+    }));
+}


### PR DESCRIPTION
#### Description

Added support for assignment operators.
#### Syntax
1. _`Type Assignable`_(`=`_`Expression`_`)? ;`

Where _`Assignable`_ is a `variable` (cannot be array access). Furthermore, _`Type`_ can be any primitive data type (`int`, `float`, `string`, `bool`) or an `Artifact` ID. 
#### Examples

```
module Example;
entity User {
    void example() {
        int a = 5;
        string b = "dassdaasd";
    }
}
```
