### PR TITLE
Added grammar for method invocation and field access

### DIFF
--- a/src/Exceptions/ParserExceptions.rsc
+++ b/src/Exceptions/ParserExceptions.rsc
@@ -2,4 +2,5 @@ module Exceptions::ParserExceptions
 
 data ParserException
     = IllegalConstructorName(str msg)
+    | IllegalObjectOperator(str msg)
     ;

--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -122,6 +122,8 @@ public Expression convertExpression((Expression) `<MemberName varName>`)
 public Expression convertExpression((Expression) `-<Expression expr>`) 
     = negative(convertExpression(expr));
 
+public Expression convertExpression((Expression) `this`) = this();
+
 public Expression convertExpression((DefaultValue) `<StringQuoted string>`)
     = strLiteral(convertStringQuoted(string));
     
@@ -163,6 +165,7 @@ public Expression convertExpression((Expression) `<Expression prev>.<MemberName 
 }
 
 private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
+private bool isValidForAccessChain((Expression) `this`) = true;
 private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) = true;

--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -140,7 +140,36 @@ public Expression convertExpression((DefaultValue) `[<{DefaultValue ","}* items>
 public Expression convertExpression((Expression) `new <ArtifactName name>`) = new("<name>", []);
 public Expression convertExpression((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) 
     = new("<name>", [convertExpression(arg) | arg <- args]);
+    
+public Expression convertExpression((Expression) `<MemberName method>(<{Expression ","}* args>)`) 
+    = invoke("<method>", [convertExpression(arg) | arg <- args]);
+    
+public Expression convertExpression((Expression) `<Expression prev>.<MemberName method>(<{Expression ","}* args>)`) {
+    
+    if (!isValidForAccessChain(prev)) {
+        throw IllegalObjectOperator("Invalid expression followed by object operator");
+    }
+    
+    return invoke(convertExpression(prev), "<method>", [convertExpression(arg) | arg <- args]);
+}
 
+public Expression convertExpression((Expression) `<Expression prev>.<MemberName field>`) {
+
+    if (!isValidForAccessChain(prev)) {
+        throw IllegalObjectOperator("Invalid expression followed by object operator");
+    }
+
+    return fieldAccess(convertExpression(prev), "<field>");
+}
+
+private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
+private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `new <ArtifactName name>`) = true;
+private bool isValidForAccessChain((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<Expression prev>.<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<Expression prev>.<MemberName field>`) = true;
+private default bool isValidForAccessChain(_) = false;
 
 
 public Declaration convertDeclaration((Declaration) `value <Type valueType><MemberName name>;`, _) 

--- a/src/Parser/Converter/Expression.rsc
+++ b/src/Parser/Converter/Expression.rsc
@@ -5,6 +5,7 @@ import Syntax::Concrete::Grammar;
 import String;
 import Parser::Converter::Boolean;
 import Parser::Converter::QuotedString;
+import Exceptions::ParserExceptions;
 
 public Expression convertExpression((Expression) `(<Expression expr>)`) = \bracket(convertExpression(expr));
 
@@ -86,4 +87,33 @@ public Expression convertExpression((DefaultValue) `[<{DefaultValue ","}* items>
 public Expression convertExpression((Expression) `new <ArtifactName name>`) = new("<name>", []);
 public Expression convertExpression((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) 
     = new("<name>", [convertExpression(arg) | arg <- args]);
+    
+public Expression convertExpression((Expression) `<MemberName method>(<{Expression ","}* args>)`) 
+    = invoke("<method>", [convertExpression(arg) | arg <- args]);
+    
+public Expression convertExpression((Expression) `<Expression prev>.<MemberName method>(<{Expression ","}* args>)`) {
+    
+    if (!isValidForAccessChain(prev)) {
+        throw IllegalObjectOperator("Invalid expression followed by object operator");
+    }
+    
+    return invoke(convertExpression(prev), "<method>", [convertExpression(arg) | arg <- args]);
+}
 
+public Expression convertExpression((Expression) `<Expression prev>.<MemberName field>`) {
+
+    if (!isValidForAccessChain(prev)) {
+        throw IllegalObjectOperator("Invalid expression followed by object operator");
+    }
+
+    return fieldAccess(convertExpression(prev), "<field>");
+}
+
+private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
+private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `new <ArtifactName name>`) = true;
+private bool isValidForAccessChain((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<Expression prev>.<MemberName method>(<{Expression ","}* args>)`) = true;
+private bool isValidForAccessChain((Expression) `<Expression prev>.<MemberName field>`) = true;
+private default bool isValidForAccessChain(_) = false;

--- a/src/Parser/Converter/Expression.rsc
+++ b/src/Parser/Converter/Expression.rsc
@@ -69,6 +69,8 @@ public Expression convertExpression((Expression) `<MemberName varName>`)
 public Expression convertExpression((Expression) `-<Expression expr>`) 
     = negative(convertExpression(expr));
 
+public Expression convertExpression((Expression) `this`) = this();
+
 public Expression convertExpression((DefaultValue) `<StringQuoted string>`)
     = strLiteral(convertStringQuoted(string));
     
@@ -110,6 +112,7 @@ public Expression convertExpression((Expression) `<Expression prev>.<MemberName 
 }
 
 private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
+private bool isValidForAccessChain((Expression) `this`) = true;
 private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) = true;

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -71,6 +71,7 @@ data Expression
     | fieldAccess(Expression prev, str field)
     | chain(list[Expression] elements)
     | emptyExpr()
+    | this()
     ;
 
 data Type

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -65,6 +65,11 @@ data Expression
     | or(Expression lhs, Expression rhs)
     | ifThenElse(Expression condition, Expression ifThen, Expression \else)
     | new(str artifact, list[Expression] args)
+    | invoke(str methodName, list[Expression] args)
+    | invoke(Expression prev, str methodName, list[Expression] args)
+    | fieldAccess(str field)
+    | fieldAccess(Expression prev, str field)
+    | chain(list[Expression] elements)
     | emptyExpr()
     ;
 

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -117,6 +117,7 @@ syntax Expression
     | newInstance: "new" ArtifactName "(" {Expression ","}* args ")"
     | invoke: (Expression prev ".")? MemberName method "(" {Expression ","}* args ")"
     | fieldAccess: Expression prev "." MemberName field
+    | this: "this"
     > left ( product: Expression lhs "*" () !>> "*" Expression rhs
            | remainder: Expression lhs "%" Expression rhs
            | division: Expression lhs "/" Expression rhs

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -113,7 +113,10 @@ syntax Expression
     | floatLiteral: DeciFloatNumeral number
     | booleanLiteral: Boolean boolean
     | variable: MemberName varName
-    | newInstance: "new" ArtifactName ("(" {Expression ","}* args ")")?
+    | newInstance: "new" ArtifactName
+    | newInstance: "new" ArtifactName "(" {Expression ","}* args ")"
+    | invoke: (Expression prev ".")? MemberName method "(" {Expression ","}* args ")"
+    | fieldAccess: Expression prev "." MemberName field
     > left ( product: Expression lhs "*" () !>> "*" Expression rhs
            | remainder: Expression lhs "%" Expression rhs
            | division: Expression lhs "/" Expression rhs
@@ -133,6 +136,10 @@ syntax Expression
     > left and: Expression lhs "&&" Expression rhs
     > left or: Expression lhs "||" Expression rhs
     > right ifThenElse: Expression condition "?" Expression thenExp ":" Expression elseExp
+    ;
+
+syntax MemberAccess
+    = 
     ;
 
 syntax Statement

--- a/src/Syntax/Concrete/Grammar/Keywords.rsc
+++ b/src/Syntax/Concrete/Grammar/Keywords.rsc
@@ -27,4 +27,5 @@ keyword GlagolPreserved
     | "break"
     | "continue"
     | "new"
+    | "this"
     ;

--- a/src/Syntax/Concrete/Grammar/Keywords.rsc
+++ b/src/Syntax/Concrete/Grammar/Keywords.rsc
@@ -26,4 +26,5 @@ keyword GlagolPreserved
     | "return"
     | "break"
     | "continue"
+    | "new"
     ;

--- a/src/Test/Parser/Expressions.rsc
+++ b/src/Test/Parser/Expressions.rsc
@@ -219,6 +219,22 @@ test bool testMethodInvokeChainedToAVariable()
     }));
 }
 
+test bool testMethodInvokeUsingThis()
+{
+    str code = "module Example;
+               'entity User {
+               '    void methodInvoke() {
+               '        this.field.nested.invoke();
+               '    }
+               '}";
+    
+    return parseModule(code) == \module("Example", {}, entity("User", {
+        method(\public(), voidValue(), "methodInvoke", [], [
+            expression(invoke(fieldAccess(fieldAccess(this(), "field"), "nested"), "invoke", []))
+          ])
+    }));
+}
+
 test bool shouldFailWhenUsingWrongExpressionsForChainedAccess()
 {
     str code = "module Example;


### PR DESCRIPTION
#### Description

Adds method invocation + field access using object operator `.` 

Both method invocation and field access are of type _`Expression`_
#### Syntax
1. _`Expression? . Identifier(Argument`_<sub>`1`</sub>_`, Argument`_<sub>`2`</sub>_`, ... Argument`_<sub>`n`</sub>`)` - method invoke 
2.  _`Expression . Identifier`_ - field access

In addition, the _`this`_ keyword was added which is of type _`Expression`_
##### Examples

```
module Example;
entity User {
    void methodInvoke() {
        this.field.nested.invoke();
    }
}
```

```
module Example;
entity User {
    void methodInvoke() {
        SomeEntity eee = new SomeEntity();
        eee.nested([\"string\"]).methodInvoke();
        this.field.nested.invoke();
    }
}
```

Last but not least, the `new` expression can also be used as a begining of the expression:

```
module Example;
entity User {
    void methodInvoke() {
        new SomeEntity().callableMethod();
    }
}
```
