### PR TITLE
Assignables can now be field access expressions

### DIFF
--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -359,3 +359,5 @@ public Expression convertParameterDefaultVal((ParameterDefaultValue) `=<DefaultV
 public Expression convertAssignable((Assignable) `<MemberName name>`) = variable("<name>");
 public Expression convertAssignable((Assignable) `<Assignable variable>[<Expression key>]`)
     = arrayAccess(convertAssignable(variable), convertExpression(key));
+public Expression convertAssignable((Assignable) `<Expression prev>.<MemberName field>`) 
+    = fieldAccess(convertExpression(prev), "<field>");

--- a/src/Parser/Converter/Assignable.rsc
+++ b/src/Parser/Converter/Assignable.rsc
@@ -2,7 +2,10 @@ module Parser::Converter::Assignable
 
 import Syntax::Abstract::AST;
 import Syntax::Concrete::Grammar;
+import Parser::Converter::Expression;
 
 public Expression convertAssignable((Assignable) `<MemberName name>`) = variable("<name>");
 public Expression convertAssignable((Assignable) `<Assignable variable>[<Expression key>]`)
     = arrayAccess(convertAssignable(variable), convertExpression(key));
+public Expression convertAssignable((Assignable) `<Expression prev>.<MemberName field>`) 
+    = fieldAccess(convertExpression(prev), "<field>");

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -139,10 +139,6 @@ syntax Expression
     > right ifThenElse: Expression condition "?" Expression thenExp ":" Expression elseExp
     ;
 
-syntax MemberAccess
-    = 
-    ;
-
 syntax Statement
     = expression: Expression expression ";"
     | block: "{" Statement* statements "}"
@@ -162,6 +158,7 @@ syntax Statement
 
 syntax Assignable
     = variable: MemberName varName
+    | fieldAccess: Expression prev "." MemberName field
     | arrayAccess: Assignable variable "[" Expression key "]"
     ;
 

--- a/src/Test/Parser/Expressions.rsc
+++ b/src/Test/Parser/Expressions.rsc
@@ -251,3 +251,22 @@ test bool shouldFailWhenUsingWrongExpressionsForChainedAccess()
     return false;
 }
 
+test bool testFieldAccessWithAssign()
+{
+    str code = "module Example;
+               'entity User {
+               '    void methodInvoke() {
+               '        this.field = \"adsdsasad\";
+               '        this.invoke().field2 += 33;
+               '        this.var = that.var2;
+               '    }
+               '}";
+    
+    return parseModule(code) == \module("Example", {}, entity("User", {
+        method(\public(), voidValue(), "methodInvoke", [], [
+            assign(fieldAccess(this(), "field"), defaultAssign(), expression(strLiteral("adsdsasad"))),
+            assign(fieldAccess(invoke(this(), "invoke", []), "field2"), additionAssign(), expression(intLiteral(33))),
+            assign(fieldAccess(this(), "var"), defaultAssign(), expression(fieldAccess(variable("that"), "var2")))
+          ])
+    }));
+}


### PR DESCRIPTION
#### Description

Assignables can now be field access expressions.
#### Syntax
1. _`Assignable Operator Statement`_

Where _`Assignable`_ is either a `variable`, an array access (_`array[index]`_) or field access (_`Expression . Identifier`_).

_`Operator`_ is one of the following assignment operators: `=`, `+=`, `-=`, `*=`, `/=`
