### PR TITLE
Added typed map type

### DIFF
--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -8,7 +8,6 @@ import String;
 import Exceptions::ParserExceptions;
 
 
-
 public Declaration convertArtifact((Artifact) `entity <ArtifactName name> {<Declaration* declarations>}`) 
     = entity("<name>", {convertDeclaration(d, "<name>") | d <- declarations});
 
@@ -353,6 +352,7 @@ public Type convertType((Type) `boolean`) = boolean();
 public Type convertType((Type) `void`) = voidValue();
 public Type convertType((Type) `string`) = string();
 public Type convertType((Type) `<Type t>[]`) = typedList(convertType(t));
+public Type convertType((Type) `{<Type key>,<Type v>}`) = typedMap(convertType(key), convertType(v));
 public Type convertType((Type) `<ArtifactName name>`) = artifactType("<name>");
 
 

--- a/src/Parser/Converter/Type.rsc
+++ b/src/Parser/Converter/Type.rsc
@@ -10,4 +10,5 @@ public Type convertType((Type) `boolean`) = boolean();
 public Type convertType((Type) `void`) = voidValue();
 public Type convertType((Type) `string`) = string();
 public Type convertType((Type) `<Type t>[]`) = typedList(convertType(t));
+public Type convertType((Type) `{<Type key>,<Type v>}`) = typedMap(convertType(key), convertType(v));
 public Type convertType((Type) `<ArtifactName name>`) = artifactType("<name>");

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -83,6 +83,7 @@ data Type
     | voidValue()
     | boolean()
     | typedList(Type \type)
+    | typedMap(Type key, Type v)
     | artifactType(str name)
     ;
     

--- a/src/Test/Parser/Repository/Maps.rsc
+++ b/src/Test/Parser/Repository/Maps.rsc
@@ -1,0 +1,25 @@
+module Test::Parser::Repository::Maps
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+
+test bool shouldParseMapDeclaration()
+{
+    str code 
+        = "module Example;
+          'repository for User {
+          '     User[] findById(int id) {
+          '         {string, int} query = {\"id\": id};
+          '         return findOneBy(query);
+          '     }
+          '}";
+    
+    return parseModule(code) == \module("Example", {}, repository("User", {
+        method(\public(), typedList(artifactType("User")), "findById", [
+            param(integer(), "id")
+        ], [
+            declare(typedMap(string(), integer()), variable("query"), expression(\map((strLiteral("id"): variable("id"))))),
+            \return(expression(invoke("findOneBy", [variable("query")])))
+        ])
+    }));
+}


### PR DESCRIPTION
#### Description

Added new type of data - typed maps
#### Syntax
1. `{`_`Type`_`,`_`Type`_`}`

Can be used everywhere where type is defined, examples:

```
module Example;
repository for User {
     User[] findById(int id) {
         {string, int} query = {"id": id};
         return findOneBy(query);
     }
}
```

```
module Example;
repository for User {
     User[] findById({string, int} ids) {
     }
}
```
