### PR TITLE
Added value objects artifact type

### DIFF
--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -21,6 +21,10 @@ public Declaration convertArtifact((Artifact) `repository for <ArtifactName name
 public Declaration convertArtifact((Artifact) `<Annotation* annotations> repository for <ArtifactName name> {<Declaration* declarations>}`)
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, repository("<name>", {convertDeclaration(d, "<name>", "repository") | d <- declarations}));
 
+public Declaration convertArtifact((Artifact) `value <ArtifactName name> {<Declaration* declarations>}`)
+    = valueObject("<name>", {convertDeclaration(d, "<name>", "value") | d <- declarations});
+    
+
 
 public AssignOperator convertAssignOperator((AssignOperator) `/=`) = divisionAssign();
 public AssignOperator convertAssignOperator((AssignOperator) `*=`) = productAssign();

--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -192,16 +192,16 @@ private bool isValidForAccessChain((Expression) `<Expression prev>.<MemberName f
 private default bool isValidForAccessChain(_) = false;
 
 
-public Declaration convertDeclaration((Declaration) `value <Type valueType><MemberName name>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Type valueType><MemberName name>;`, _, _) 
     = \value(convertType(valueType), "<name>");
     
-public Declaration convertDeclaration((Declaration) `value <Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
     = \value(convertType(valueType), "<name>", convertAccessProperties(accessProperties));
     
-public Declaration convertDeclaration((Declaration) `<Annotation* annotations>value <Type valueType><MemberName name>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Annotation* annotations><Type valueType><MemberName name>;`, _, _) 
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, \value(convertType(valueType), "<name>"));
     
-public Declaration convertDeclaration((Declaration) `<Annotation* annotations>value <Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Annotation* annotations><Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, \value(convertType(valueType), "<name>", convertAccessProperties(accessProperties)));
 
 
@@ -232,7 +232,8 @@ public Statement convertStmt((Statement) `if ( <Expression condition> ) <Stateme
 public Statement convertStmt((Statement) `<Assignable assignable><AssignOperator operator><Statement val>`) 
     = assign(convertAssignable(assignable), convertAssignOperator(operator), convertStmt(val));
 
-public Statement convertStmt((Statement) `return <Statement stmt>`) = \return(convertStmt(stmt));
+public Statement convertStmt((Statement) `return;`) = \return(expression(emptyStmt()));
+public Statement convertStmt((Statement) `return <Expression expr>;`) = \return(expression(convertExpression(expr)));
 
 public Statement convertStmt((Statement) `break ;`) = \break();
 public Statement convertStmt((Statement) `break<Integer level>;`) = \break(toInt("<level>"));

--- a/src/Parser/Converter/Artifact.rsc
+++ b/src/Parser/Converter/Artifact.rsc
@@ -19,3 +19,7 @@ public Declaration convertArtifact((Artifact) `repository for <ArtifactName name
 
 public Declaration convertArtifact((Artifact) `<Annotation* annotations> repository for <ArtifactName name> {<Declaration* declarations>}`)
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, repository("<name>", {convertDeclaration(d, "<name>", "repository") | d <- declarations}));
+
+public Declaration convertArtifact((Artifact) `value <ArtifactName name> {<Declaration* declarations>}`)
+    = valueObject("<name>", {convertDeclaration(d, "<name>", "value") | d <- declarations});
+    

--- a/src/Parser/Converter/Declaration/Value.rsc
+++ b/src/Parser/Converter/Declaration/Value.rsc
@@ -6,14 +6,14 @@ import Parser::Converter::Type;
 import Parser::Converter::AccessProperty;
 import Parser::Converter::Annotation;
 
-public Declaration convertDeclaration((Declaration) `value <Type valueType><MemberName name>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Type valueType><MemberName name>;`, _, _) 
     = \value(convertType(valueType), "<name>");
     
-public Declaration convertDeclaration((Declaration) `value <Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
     = \value(convertType(valueType), "<name>", convertAccessProperties(accessProperties));
     
-public Declaration convertDeclaration((Declaration) `<Annotation* annotations>value <Type valueType><MemberName name>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Annotation* annotations><Type valueType><MemberName name>;`, _, _) 
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, \value(convertType(valueType), "<name>"));
     
-public Declaration convertDeclaration((Declaration) `<Annotation* annotations>value <Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
+public Declaration convertDeclaration((Declaration) `<Annotation* annotations><Type valueType><MemberName name><AccessProperties accessProperties>;`, _, _) 
     = annotated({convertAnnotation(annotation) | annotation <- annotations}, \value(convertType(valueType), "<name>", convertAccessProperties(accessProperties)));

--- a/src/Parser/Converter/Statement.rsc
+++ b/src/Parser/Converter/Statement.rsc
@@ -21,7 +21,8 @@ public Statement convertStmt((Statement) `if ( <Expression condition> ) <Stateme
 public Statement convertStmt((Statement) `<Assignable assignable><AssignOperator operator><Statement val>`) 
     = assign(convertAssignable(assignable), convertAssignOperator(operator), convertStmt(val));
 
-public Statement convertStmt((Statement) `return <Statement stmt>`) = \return(convertStmt(stmt));
+public Statement convertStmt((Statement) `return;`) = \return(expression(emptyStmt()));
+public Statement convertStmt((Statement) `return <Expression expr>;`) = \return(expression(convertExpression(expr)));
 
 public Statement convertStmt((Statement) `break ;`) = \break();
 public Statement convertStmt((Statement) `break<Integer level>;`) = \break(toInt("<level>"));

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -7,6 +7,7 @@ data Declaration
     | annotated(set[Annotation] annotations, Declaration declaration)
     | entity(str name, set[Declaration] declarations)
     | repository(str name, set[Declaration] declarations)
+    | valueObject(str name, set[Declaration] declarations)
     | \value(Type \valueType, str name, set[AccessProperty] valueProperties)
     | inject(str artifactName, str as)
     | relation(RelationDir l, RelationDir r, str name, str as, set[AccessProperty] valueProperties)

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -54,7 +54,7 @@ syntax AnnotationValue
     ;
 
 syntax Declaration
-    = Annotation* annotations "value" Type type MemberName name AccessProperties? accessProperties ";"
+    = Annotation* annotations Type type MemberName name AccessProperties? accessProperties ";"
     | "relation" RelationDir l ":" RelationDir r ArtifactName entity "as" MemberName alias AccessProperties? accessProperties ";"
     | ArtifactName "(" {Parameter ","}* parameters ")" "{" Statement* body "}" (When when ";")?
     | ArtifactName "(" {Parameter ","}* parameters ")" When? when ";"
@@ -156,7 +156,7 @@ syntax Statement
     | assign: Assignable assignable AssignOperator operator Statement value !emptyStmt!block!ifThen!ifThenElse!return!break
     | foreach: "for" "(" Expression list "as" MemberName var (","  {Expression ","}+ conditions)? ")" Statement body
     > non-assoc  (
-            \return: "return" Statement stmt !block!ifThen!ifThenElse!foreach!declare!break
+            \return: "return" Expression? expr ";"
         |   \break: "break" Integer? level ";"
         |   \continue: "continue" Integer? level ";"
         |   declare: Type type MemberName varName "=" Statement defaultValue !emptyStmt!block!ifThen!ifThenElse!return!declare

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -23,6 +23,7 @@ syntax ImportAlias
 syntax Artifact
     = Annotation* annotations "entity" ArtifactName name "{" Declaration* declarations "}"
     | Annotation* annotations "repository" "for" ArtifactName name "{" Declaration* declarations "}"
+    | "value" ArtifactName name "{" Declaration* declarations "}"
     ;
 
 syntax Annotation

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -3,7 +3,8 @@ module Test::Parser::Entity::Basics
 import Parser::ParseAST;
 import Syntax::Abstract::AST;
 
-test bool entityDeclaration() {
+test bool entityDeclaration() 
+{
     str code 
         = "module Testing;
         'entity User {}

--- a/src/Test/Parser/Entity/NamingConstraints.rsc
+++ b/src/Test/Parser/Entity/NamingConstraints.rsc
@@ -109,7 +109,7 @@ test bool entityValuesShouldStartWithLowerCaseAndBeAlphaCharsOnly()
     str failCodeUpperCaseFirst
         = "module Example;
           'entity User {
-          '    value int MyValue with {get, set};
+          '    int MyValue with {get, set};
           '}
           '";
     
@@ -119,7 +119,7 @@ test bool entityValuesShouldStartWithLowerCaseAndBeAlphaCharsOnly()
     str failCodeUnderscore 
         = "module Example;
           'entity User {
-          '    value int my_Value with {get, set};
+          '    int my_Value with {get, set};
           '}
           '";
     
@@ -131,7 +131,7 @@ test bool entityValuesShouldStartWithLowerCaseAndBeAlphaCharsOnly()
     str successCode 
         = "module Example;
           'entity User {
-          '    value int myValue with {get, set};
+          '    int myValue with {get, set};
           '}
           '";
     

--- a/src/Test/Parser/Entity/Values.rsc
+++ b/src/Test/Parser/Entity/Values.rsc
@@ -7,8 +7,8 @@ test bool testShouldParseEntityWithValues()
 {
     str code = "module Example;
                'entity User {
-               '    value int id with {get};
-               '    value Date addedOn with {get, set};
+               '    int id with {get};
+               '    Date addedOn with {get, set};
                '}";
                
     set[Declaration] expectedValues = {
@@ -31,7 +31,7 @@ test bool testShouldParseEntityWithValuesAndAnnotations()
                '        size: 11,
                '        column: \"id\"
                '    })
-               '    value int id with {get};
+               '    int id with {get};
                '}";
 
     return parseModule(code) == \module("Example", {}, entity("User", {

--- a/src/Test/Parser/ValueObject/Basics.rsc
+++ b/src/Test/Parser/ValueObject/Basics.rsc
@@ -1,0 +1,14 @@
+module Test::Parser::ValueObject::Basics
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+
+test bool shouldParseEmptyValueObject()
+{
+    str code 
+        = "module Testing;
+        'value DateTime {}
+        '";
+        
+    return parseModule(code) == \module("Testing", {}, valueObject("DateTime", {}));
+}


### PR DESCRIPTION
#### Description

You can now declare value objects
#### Syntax
- `value`_`ArtifactName`_`{`_`Declaration*`_`}`

In addition, the `value` keyword has been removed from value-properties  declarations within artifacts.
