### PR TITLE
Added new module-namespaces data structure

### DIFF
--- a/src/Parser/Converter.rsc
+++ b/src/Parser/Converter.rsc
@@ -9,6 +9,13 @@ import Exceptions::ParserExceptions;
 
 
 
+public Declaration buildAST((Module) `module <Namespace n>;<Import* imports>`) 
+    = \module(convertModuleNamespace(n), {convertImport(\import) | \import <- imports});
+
+public Declaration buildAST((Module) `module <Namespace n>;<Import* imports><Artifact artifact>`) 
+    = \module(convertModuleNamespace(n), {convertImport(\import) | \import <- imports}, convertArtifact(artifact));
+
+
 public Declaration convertArtifact((Artifact) `entity <ArtifactName name> {<Declaration* declarations>}`) 
     = entity("<name>", {convertDeclaration(d, "<name>", "entity") | d <- declarations});
 
@@ -225,6 +232,11 @@ public bool convertBoolean((Boolean) `true`) = true;
 public bool convertBoolean((Boolean) `false`) = false;
 
 
+public Declaration convertModuleNamespace((Namespace) `<Name name>`) = namespace("<name>");
+public Declaration convertModuleNamespace((Namespace) `<Name name>::<Namespace n>`) 
+    = namespace("<name>", convertModuleNamespace(n));
+
+
 public Statement convertStmt((Statement) `<Expression expr>;`) = expression(convertExpression(expr));
 public Statement convertStmt((Statement) `;`) = emptyStmt();
 public Statement convertStmt((Statement) `{<Statement* stmts>}`) = block([convertStmt(stmt) | stmt <- stmts]);
@@ -330,13 +342,12 @@ public Type convertType((Type) `<ArtifactName name>`) = artifactType("<name>");
 public Expression convertWhen((When) `when <Expression expr>`) = convertExpression(expr);
 
 
-public Declaration convertImport((Import) `import <ImportNamespace* namespace><ArtifactName artifact><ImportAlias as>;`)
-    = \import("<artifact>", [convertImportNamespace(n) | n <- namespace], convertImportAlias(as));
+public Declaration convertImport((Import) `import <Namespace n>::<ArtifactName artifact><ImportAlias as>;`)
+    = \import("<artifact>", convertModuleNamespace(n), convertImportAlias(as));
     
-public Declaration convertImport((Import) `import <ImportNamespace* namespace><ArtifactName artifact>;`)
-    = \import("<artifact>", [convertImportNamespace(n) | n <- namespace], "<artifact>");
+public Declaration convertImport((Import) `import <Namespace n>::<ArtifactName artifact>;`)
+    = \import("<artifact>", convertModuleNamespace(n), "<artifact>");
 
-private str convertImportNamespace((ImportNamespace) `<ArtifactName part>::`) = "<part>";
 private str convertImportAlias((ImportAlias) `as <ArtifactName as>`) = "<as>";
 
 

--- a/src/Parser/Converter/Import.rsc
+++ b/src/Parser/Converter/Import.rsc
@@ -2,12 +2,12 @@ module Parser::Converter::Import
 
 import Syntax::Abstract::AST;
 import Syntax::Concrete::Grammar;
+import Parser::Converter::ModuleNamespace;
 
-public Declaration convertImport((Import) `import <ImportNamespace* namespace><ArtifactName artifact><ImportAlias as>;`)
-    = \import("<artifact>", [convertImportNamespace(n) | n <- namespace], convertImportAlias(as));
+public Declaration convertImport((Import) `import <Namespace n>::<ArtifactName artifact><ImportAlias as>;`)
+    = \import("<artifact>", convertModuleNamespace(n), convertImportAlias(as));
     
-public Declaration convertImport((Import) `import <ImportNamespace* namespace><ArtifactName artifact>;`)
-    = \import("<artifact>", [convertImportNamespace(n) | n <- namespace], "<artifact>");
+public Declaration convertImport((Import) `import <Namespace n>::<ArtifactName artifact>;`)
+    = \import("<artifact>", convertModuleNamespace(n), "<artifact>");
 
-private str convertImportNamespace((ImportNamespace) `<ArtifactName part>::`) = "<part>";
 private str convertImportAlias((ImportAlias) `as <ArtifactName as>`) = "<as>";

--- a/src/Parser/Converter/Module.rsc
+++ b/src/Parser/Converter/Module.rsc
@@ -1,0 +1,11 @@
+module Parser::Converter::Module
+
+import Syntax::Abstract::AST;
+import Syntax::Concrete::Grammar;
+import Parser::Converter::ModuleNamespace;
+
+public Declaration buildAST((Module) `module <Namespace n>;<Import* imports>`) 
+    = \module(convertModuleNamespace(n), {convertImport(\import) | \import <- imports});
+
+public Declaration buildAST((Module) `module <Namespace n>;<Import* imports><Artifact artifact>`) 
+    = \module(convertModuleNamespace(n), {convertImport(\import) | \import <- imports}, convertArtifact(artifact));

--- a/src/Parser/Converter/ModuleNamespace.rsc
+++ b/src/Parser/Converter/ModuleNamespace.rsc
@@ -1,0 +1,8 @@
+module Parser::Converter::ModuleNamespace
+
+import Syntax::Abstract::AST;
+import Syntax::Concrete::Grammar;
+
+public Declaration convertModuleNamespace((Namespace) `<Name name>`) = namespace("<name>");
+public Declaration convertModuleNamespace((Namespace) `<Name name>::<Namespace n>`) 
+    = namespace("<name>", convertModuleNamespace(n));

--- a/src/Parser/ParseAST.rsc
+++ b/src/Parser/ParseAST.rsc
@@ -4,16 +4,10 @@ import Syntax::Abstract::AST;
 import Syntax::Concrete::Grammar;
 import Parser::ParseCode;
 import ParseTree;
+import Parser::Converter::Module;
 import Parser::Converter;
 
 public Declaration parseModule(str code) = buildAST(parseCode(code));
 public Declaration parseModule(loc file) = buildAST(parseFile(file));
 
 public Declaration buildAST(start[Test] t) = buildAST(t.top);
-
-public Declaration buildAST((Module) `module <Name name>;<Import* imports>`) 
-    = \module("<name>", {convertImport(\import) | \import <- imports});
-
-public Declaration buildAST((Module) `module <Name name>;<Import* imports><Artifact artifact>`) 
-    = \module("<name>", {convertImport(\import) | \import <- imports}, convertArtifact(artifact));
-    

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -1,9 +1,11 @@
 module Syntax::Abstract::AST
 
 data Declaration 
-    = \module(str name, set[Declaration] imports)
-    | \module(str name, set[Declaration] imports, Declaration artifact)
-    | \import(str artifactName, list[str] namespace, str as)
+    = \module(Declaration namespace, set[Declaration] imports)
+    | \module(Declaration namespace, set[Declaration] imports, Declaration artifact)
+    | namespace(str name)
+    | namespace(str name, Declaration subNamespace)
+    | \import(str artifactName, Declaration namespace, str as)
     | annotated(set[Annotation] annotations, Declaration declaration)
     | entity(str name, set[Declaration] declarations)
     | repository(str name, set[Declaration] declarations)

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -5,15 +5,16 @@ extend Syntax::Concrete::Grammar::Layout;
 extend Syntax::Concrete::Grammar::Lexical;
 
 start syntax Module
-   = \module: ^"module" Name name ";" Import* imports Artifact? artifact
+   = \module: ^"module" Namespace namespace ";" Import* imports Artifact? artifact
    ;
 
-syntax Import
-    = \import: "import" ImportNamespace* namespace ArtifactName artifact ImportAlias? alias ";"
+syntax Namespace 
+    = Name name
+    | Name name "::" Namespace sub
     ;
-    
-syntax ImportNamespace
-    = namespace: ArtifactName "::"
+
+syntax Import
+    = \import: "import" Namespace namespace "::" ArtifactName artifact ImportAlias? alias ";"
     ;
     
 syntax ImportAlias

--- a/src/Test/Parser/Entity/Annotations.rsc
+++ b/src/Test/Parser/Entity/Annotations.rsc
@@ -9,7 +9,7 @@ test bool testShouldParseTableNameAnnotationForEntity()
                '@table(\"users\")
                'entity User { }";
 
-    return parseModule(code) == \module("Example", {}, 
+    return parseModule(code) == \module(namespace("Example"), {},
         annotated({annotation("table", [annotationVal("users")])}, entity("User", {})));
 }
 
@@ -25,7 +25,7 @@ test bool testShouldParseIndexesAnnotationForEntity()
         annotation("index", [annotationVal("second_index"), annotationVal([annotationVal("quantity"), annotationVal("total")])])
     }, entity("User", {}));
 
-    return parseModule(code) == \module("Example", {}, expectedEntity);
+    return parseModule(code) == \module(namespace("Example"), {}, expectedEntity);
 }
 
 test bool testShouldParseCompositeAnnotationForEntity()
@@ -42,5 +42,5 @@ test bool testShouldParseCompositeAnnotationForEntity()
         annotation("table", [annotationVal("my_users_table")])
     }, entity("User", {}));
 
-    return parseModule(code) == \module("Example", {}, expectedEntity);
+    return parseModule(code) == \module(namespace("Example"), {}, expectedEntity);
 }

--- a/src/Test/Parser/Entity/Basics.rsc
+++ b/src/Test/Parser/Entity/Basics.rsc
@@ -10,7 +10,7 @@ test bool entityDeclaration()
         'entity User {}
         '";
         
-    return parseModule(code) == \module("Testing", {}, entity("User", {}));
+    return parseModule(code) == \module(namespace("Testing"), {}, entity("User", {}));
 }
 
 test bool testShouldParseEmptyEntityWithModuleImports()
@@ -22,10 +22,10 @@ test bool testShouldParseEmptyEntityWithModuleImports()
                'entity User {}";
 
    set[Declaration] expectedImports = {
-        \import("User", ["Auth"], "UserEntity"),
-        \import("Money", ["I18n"], "Money"),
-        \import("Language", ["I18n"], "Language")
+        \import("User", namespace("Auth"), "UserEntity"),
+        \import("Money", namespace("I18n"), "Money"),
+        \import("Language", namespace("I18n"), "Language")
    };
 
-    return parseModule(code) == \module("Example", expectedImports, entity("User", {}));
+    return parseModule(code) == \module(namespace("Example"), expectedImports, entity("User", {}));
 }

--- a/src/Test/Parser/Entity/Constructors.rsc
+++ b/src/Test/Parser/Entity/Constructors.rsc
@@ -13,7 +13,7 @@ test bool shouldParseConstructWithOneParam()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "param")], [])
     }));
 }
@@ -44,7 +44,7 @@ test bool shouldParseConstructWithTwoParamsAndDefaultValue()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([
             param(integer(), "param"),
             param(float(), "param2", floatLiteral(0.55)),
@@ -65,7 +65,7 @@ test bool shouldParseConstructWithBody()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([
             param(integer(), "param"),
             param(float(), "param2", floatLiteral(0.55)),
@@ -87,7 +87,7 @@ test bool shouldParseConstructWithoutParams()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [])
     }));
 }
@@ -101,7 +101,7 @@ test bool shouldParseConstructWithoutBody()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [])
     }));
 }
@@ -115,7 +115,7 @@ test bool shouldParseConstructWithoutBodyWithParams()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([
             param(integer(), "param"),
             param(float(), "param2", floatLiteral(0.55)),
@@ -135,7 +135,7 @@ test bool shouldParseConstructWithWhen()
           '}
           '";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([
                 param(integer(), "param")
             ], [], and(

--- a/src/Test/Parser/Entity/Methods.rsc
+++ b/src/Test/Parser/Entity/Methods.rsc
@@ -12,7 +12,7 @@ test bool shouldParseMethodWithoutModifier()
         '}";
     
     return parseModule(code) == 
-      \module("Example", {}, 
+      \module(namespace("Example"), {},
         entity("User", { 
             method(\public(), integer(), "example", [
                     param(integer(), "blabla", intLiteral(5)),
@@ -35,7 +35,7 @@ test bool shouldParseMethodWithModifierAndWhenExpression()
         '}";
         
     return parseModule(code) == 
-      \module("Example", {}, 
+      \module(namespace("Example"), {},
         entity("User", { 
             method(\private(), integer(), "example", [
                     param(integer(), "argument")
@@ -59,7 +59,7 @@ test bool shouldParseMethodWithModifierBodyAndWhen()
         '}";
         
     return parseModule(code) == 
-      \module("Example", {}, 
+      \module(namespace("Example"), {},
         entity("User", { 
             method(\private(), voidValue(), "processEntry", [
                     param(integer(), "limit", intLiteral(15))

--- a/src/Test/Parser/Entity/Relations.rsc
+++ b/src/Test/Parser/Entity/Relations.rsc
@@ -11,7 +11,7 @@ test bool testShouldParseEntityRelations()
                '    relation one:many User as userFriends with {add, set, get, clear};
                '}";
 
-   return parseModule(code) == \module("Example", {}, entity("User", {
+   return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
        relation(\one(), \one(), "Language", "userLanguage", {}),
        relation(\one(), many(), "User", "userFriends", {add(), \set(), get(), clear()})
    }));

--- a/src/Test/Parser/Entity/Values.rsc
+++ b/src/Test/Parser/Entity/Values.rsc
@@ -16,7 +16,7 @@ test bool testShouldParseEntityWithValues()
         \value(artifactType("Date"), "addedOn", {get(), \set()})
     };
 
-    return parseModule(code) == \module("Example", {}, entity("User", expectedValues));
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", expectedValues));
 }
 
 
@@ -34,7 +34,7 @@ test bool testShouldParseEntityWithValuesAndAnnotations()
                '    int id with {get};
                '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         annotated({
             annotation("field", [
                 annotationMap((

--- a/src/Test/Parser/Expressions.rsc
+++ b/src/Test/Parser/Expressions.rsc
@@ -14,7 +14,7 @@ test bool testShouldParseVariableInBrackets()
                '    }
                '}"; 
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "variableInBrackets", [param(integer(), "theVariable")], [
             expression(\bracket(\bracket(variable("theVariable")))),
             expression(addition(\bracket(variable("theVariable")), intLiteral(1)))
@@ -34,7 +34,7 @@ test bool testShouldParseList()
                '    }
                '}";
                
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "arrayExpression", [], [
             expression(\list([strLiteral("First thing"), strLiteral("Second thing")])),
             expression(\list([intLiteral(1), intLiteral(2), intLiteral(3), intLiteral(4), intLiteral(5)])),
@@ -53,7 +53,7 @@ test bool testShouldParseExpressionsWithNegativeLiterals()
                '    }
                '}";
                
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "nestedNegative", [], [
             expression(negative(\bracket(negative(\bracket(negative(\bracket(intLiteral(23))))))))
         ])
@@ -75,7 +75,7 @@ test bool testShouldParseMathExpressions()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "math", [], [
             expression(subtraction(
                   product(
@@ -115,7 +115,7 @@ test bool shouldParseAllTypesOfLiterals()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "literals", [param(integer(), "var")], [
             expression(strLiteral("simple string literal")),
             expression(intLiteral(123)),
@@ -136,7 +136,7 @@ test bool testNewInstance()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "newInstance", [], [
             expression(new("DateTime", []))
           ])
@@ -152,7 +152,7 @@ test bool testNewInstanceWithArg()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "newInstance", [], [
             expression(new("DateTime", [strLiteral("now")]))
           ])
@@ -168,7 +168,7 @@ test bool testNewInstanceWithArgs()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "newInstance", [], [
             expression(new("DateTime", [strLiteral("now"), new("Money", [
                 intLiteral(2300), strLiteral("USD")
@@ -186,7 +186,7 @@ test bool testMethodInvoke()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "methodInvoke", [], [
             expression(invoke("methodInvoke", []))
           ])
@@ -206,7 +206,7 @@ test bool testMethodInvokeChainedToAVariable()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "methodInvoke", [], [
             declare(artifactType("SomeEntity"), variable("eee"), expression(
                 new("SomeEntity", [])
@@ -228,7 +228,7 @@ test bool testMethodInvokeUsingThis()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "methodInvoke", [], [
             expression(invoke(fieldAccess(fieldAccess(this(), "field"), "nested"), "invoke", []))
           ])
@@ -262,7 +262,7 @@ test bool testFieldAccessWithAssign()
                '    }
                '}";
     
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         method(\public(), voidValue(), "methodInvoke", [], [
             assign(fieldAccess(this(), "field"), defaultAssign(), expression(strLiteral("adsdsasad"))),
             assign(fieldAccess(invoke(this(), "invoke", []), "field2"), additionAssign(), expression(intLiteral(33))),

--- a/src/Test/Parser/ModuleBasics.rsc
+++ b/src/Test/Parser/ModuleBasics.rsc
@@ -6,7 +6,7 @@ import Syntax::Abstract::AST;
 test bool moduleDeclaration() {
     str code = "module Testing;";
     
-    return parseModule(code) == \module("Testing", {});
+    return parseModule(code) == \module(namespace("Testing"), {});
 }
 
 test bool moduleDeclarationWithWhitespace() {
@@ -15,23 +15,30 @@ test bool moduleDeclarationWithWhitespace() {
     '
     ";
     
-    return parseModule(code) == \module("Testing", {});
+    return parseModule(code) == \module(namespace("Testing"), {});
 }
 
 test bool moduleDeclarationWithImports() {
     str code = "module Testing;
-    'import User;
+    'import Example::User;
     'import I18n::Language as LanguageEntity;
     'import News::Comment;
     'import News::Article as ArticleEntity;
     ";
     
-    return parseModule(code) == \module("Testing", {
-        \import("User", [], "User"),
-        \import("Language", ["I18n"], "LanguageEntity"),
-        \import("Article", ["News"], "ArticleEntity"),
-        \import("Comment", ["News"], "Comment")
+    return parseModule(code) == \module(namespace("Testing"), {
+        \import("User", namespace("Example"), "User"),
+        \import("Language", namespace("I18n"), "LanguageEntity"),
+        \import("Article", namespace("News"), "ArticleEntity"),
+        \import("Comment", namespace("News"), "Comment")
     });
 }
 
-
+test bool moduleDeclarationWithSubModule() {
+    str code = "module Testing::SubName;
+    '
+    '
+    ";
+    
+    return parseModule(code) == \module(namespace("Testing", namespace("SubName")), {});
+}

--- a/src/Test/Parser/Repository/Basics.rsc
+++ b/src/Test/Parser/Repository/Basics.rsc
@@ -13,8 +13,8 @@ test bool shouldParseEmptyRepository()
           'repository for User {
           '}";
     
-    return parseModule(code) == \module("Example", {
-        \import("EntityManager", ["Glagol", "ORM"], "EntityManager")
+    return parseModule(code) == \module(namespace("Example"), {
+        \import("EntityManager", namespace("Glagol", namespace("ORM")), "EntityManager")
     }, repository("User", {}));
 }
 
@@ -26,7 +26,7 @@ test bool shouldParseRepositoryWithMethodAndAMap()
           '     User[] findById(int id) = findOneBy({\"id\": id});
           '}";
     
-    return parseModule(code) == \module("Example", {}, repository("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, repository("User", {
         method(\public(), typedList(artifactType("User")), "findById", [
             param(integer(), "id")
         ], [\return(expression(

--- a/src/Test/Parser/Repository/Injections.rsc
+++ b/src/Test/Parser/Repository/Injections.rsc
@@ -15,8 +15,8 @@ test bool shouldParseInjections()
           '     inject EntityManager as em;
           '}";
     
-    return parseModule(code) == \module("Example", {
-        \import("EntityManager", ["Glagol", "ORM"], "EntityManager")
+    return parseModule(code) == \module(namespace("Example"), {
+        \import("EntityManager", namespace("Glagol", namespace("ORM")), "EntityManager")
     }, repository("User", {
         inject("EntityManager", "em")
     }));

--- a/src/Test/Parser/Repository/Maps.rsc
+++ b/src/Test/Parser/Repository/Maps.rsc
@@ -14,7 +14,7 @@ test bool shouldParseMapDeclaration()
           '     }
           '}";
     
-    return parseModule(code) == \module("Example", {}, repository("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, repository("User", {
         method(\public(), typedList(artifactType("User")), "findById", [
             param(integer(), "id")
         ], [

--- a/src/Test/Parser/Statements.rsc
+++ b/src/Test/Parser/Statements.rsc
@@ -15,7 +15,7 @@ test bool testDeclarationsWithPrimitiveTypes() {
         '   }
         '}";
         
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [
             declare(float(), variable("myVariable"), expression(floatLiteral(5.4))),
             declare(integer(), variable("yourVariable"), expression(intLiteral(23))),
@@ -37,7 +37,7 @@ test bool testDeclarationsWithoutDefaultValue() {
         '   }
         '}";
         
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [
             declare(float(), variable("myVariable")),
             declare(integer(), variable("yourVariable")),
@@ -55,7 +55,7 @@ test bool testDeclarationsWithCustomTypes() {
         '   }
         '}";
         
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [
             declare(artifactType("DateTime"), variable("myDate"))
         ])
@@ -71,7 +71,7 @@ test bool testDeclarationsWithNestedAssignment() {
         '   }
         '}";
         
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             declare(integer(), variable("myNumber"), assign(variable("a"), defaultAssign(), expression(intLiteral(5))))
         ])
@@ -87,7 +87,7 @@ test bool testIfStatement() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             ifThen(equals(variable("a"), intLiteral(5)), \return(expression(intLiteral(5))))
         ])
@@ -103,7 +103,7 @@ test bool testIfStatementWithBlock() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             ifThen(equals(variable("a"), intLiteral(5)), block([\return(expression(intLiteral(5)))]))
         ])
@@ -120,7 +120,7 @@ test bool testIfElseStatement() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             ifThenElse(equals(variable("a"), intLiteral(5)), \return(expression(intLiteral(5))), \return(expression(intLiteral(6))))
         ])
@@ -137,7 +137,7 @@ test bool testIfElseIfStatement() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             ifThenElse(equals(variable("a"), intLiteral(5)), \return(expression(intLiteral(5))), 
                 ifThen(equals(variable("a"), intLiteral(6)), \return(expression(intLiteral(6))))    
@@ -157,7 +157,7 @@ test bool testIfElseIfEndingWithElseStatement() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(integer(), "a")], [
             ifThenElse(equals(variable("a"), intLiteral(5)), \return(expression(intLiteral(5))), 
                 ifThenElse(equals(variable("a"), intLiteral(6)), \return(expression(intLiteral(6))), \return(expression(intLiteral(0))))
@@ -175,7 +175,7 @@ test bool testForeachStatementWithEmptyStmt() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(typedList(integer()), "a")], [
             foreach(variable("a"), variable("b"), emptyStmt())
         ])
@@ -191,7 +191,7 @@ test bool testForeachStatementWithEmptyStmtAndDirectList() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [
             foreach(\list([intLiteral(1), intLiteral(2), intLiteral(3), intLiteral(4), intLiteral(5)]), 
                 variable("b"), emptyStmt())
@@ -209,7 +209,7 @@ test bool testForeachStatementWithIncrementStmtAndDirectList() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([], [
             declare(integer(), variable("i")),
             foreach(\list([intLiteral(1), intLiteral(2), intLiteral(3), intLiteral(4), intLiteral(5)]), 
@@ -229,7 +229,7 @@ test bool testForeachStatementWithBreak() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(typedList(integer()), "a")], [
             foreach(variable("a"), variable("b"), block([
                 ifThen(greaterThan(variable("a"), intLiteral(2)), \break())
@@ -250,7 +250,7 @@ test bool testForeachStatementWithLevelledBreak() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(typedList(integer()), "a")], [
             foreach(variable("a"), variable("b"), 
                 foreach(variable("c"), variable("d"), 
@@ -270,7 +270,7 @@ test bool testForeachStatementWithCondition() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(typedList(artifactType("DateTime")), "a"), param(artifactType("DateTime"), "now")], [
             foreach(variable("a"), variable("b"), emptyStmt(), [lessThan(variable("a"), variable("now"))])
         ])
@@ -287,7 +287,7 @@ test bool testForeachStatementWithContinue() {
         '   }
         '}";
 
-    return parseModule(code) == \module("Example", {}, entity("User", {
+    return parseModule(code) == \module(namespace("Example"), {}, entity("User", {
         constructor([param(typedList(artifactType("DateTime")), "a"), param(artifactType("DateTime"), "now")], [
             foreach(variable("a"), variable("b"), ifThen(
                 lessThan(variable("a"), variable("now")), \continue()

--- a/src/Test/Parser/Util/Basics.rsc
+++ b/src/Test/Parser/Util/Basics.rsc
@@ -9,7 +9,7 @@ test bool shouldParseEmptyUtil()
         = "module Test;
           'util UserCreator {}";
           
-    return parseModule(code) == \module("Test", {}, util("UserCreator", {}));
+    return parseModule(code) == \module(namespace("Test"), {}, util("UserCreator", {}));
 }
 
 test bool shouldParseUtilUsingTheServiceKeyword()
@@ -18,5 +18,5 @@ test bool shouldParseUtilUsingTheServiceKeyword()
         = "module Test;
           'service UserCreator {}";
           
-    return parseModule(code) == \module("Test", {}, util("UserCreator", {}));
+    return parseModule(code) == \module(namespace("Test"), {}, util("UserCreator", {}));
 }

--- a/src/Test/Parser/ValueObject/Basics.rsc
+++ b/src/Test/Parser/ValueObject/Basics.rsc
@@ -10,5 +10,5 @@ test bool shouldParseEmptyValueObject()
         'value DateTime {}
         '";
         
-    return parseModule(code) == \module("Testing", {}, valueObject("DateTime", {}));
+    return parseModule(code) == \module(namespace("Testing"), {}, valueObject("DateTime", {}));
 }


### PR DESCRIPTION
#### Description

Improved module namespacing. Now nested modules can be added + changed the way they are structured in the AST.
#### Syntax
- `module`_`Namespace*`_`::`_`ArtifactName`_`;`

Where _`Namespace`_ is one of the following:
1. _`Name`_
2. _`Name`_`::`_`Namespace`_

The `import` declarations are also updated to use the same _`Namespace`_ grammar:
1. `import`_`Namespace`_`::`_`Artifact`_`;`
2. `import`_`Namespace`_`::`_`Artifact`_`as`_`Alias`_`;`
