### PR TITLE
Added associated artifact injection/expressions for repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build.properties
 .classpath
 src/Tests.rsc
 *.orig
+glagol-dsl.iml

--- a/src/Parser/Converter/Artifact.rsc
+++ b/src/Parser/Converter/Artifact.rsc
@@ -24,8 +24,8 @@ public Declaration convertArtifact((Artifact) `value <ArtifactName name> {<Decla
     = valueObject("<name>", {convertDeclaration(d, "<name>", "value") | d <- declarations});
     
 public Declaration convertArtifact((Artifact) `util <ArtifactName name> {<Declaration* declarations>}`)
-    = util("<name>", {convertDeclaration(d, "<name>", "value") | d <- declarations});
+    = util("<name>", {convertDeclaration(d, "<name>", "util") | d <- declarations});
     
 public Declaration convertArtifact((Artifact) `service <ArtifactName name> {<Declaration* declarations>}`)
-    = util("<name>", {convertDeclaration(d, "<name>", "value") | d <- declarations});
+    = util("<name>", {convertDeclaration(d, "<name>", "util") | d <- declarations});
     

--- a/src/Parser/Converter/Declaration/Inject.rsc
+++ b/src/Parser/Converter/Declaration/Inject.rsc
@@ -4,11 +4,25 @@ import Syntax::Abstract::AST;
 import Syntax::Concrete::Grammar;
 import Exceptions::ParserExceptions;
 
+private list[str] allowedArtifactTypes = ["repository", "util"];
+
 public Declaration convertDeclaration((Declaration) `inject <ArtifactName artifact>as<MemberName as>;`, _, str artifactType) {
     
-    if (artifactType != "repository") {
+    if (artifactType notin allowedArtifactTypes) {
         throw IllegalMember("Injection is not allowed in \"<artifactType>\"");
     }
     
     return inject("<artifact>", "<as>");   
 }
+
+public Declaration convertDeclaration((Declaration) `inject <AssocArtifact assocArtifact>as<MemberName as>;`, _, str artifactType) {
+    
+    if (artifactType notin allowedArtifactTypes) {
+        throw IllegalMember("Injection is not allowed in \"<artifactType>\"");
+    }
+    
+    return inject(convertAssocArtifact(assocArtifact), "<as>");   
+}
+
+public AssocArtifact convertAssocArtifact((AssocArtifact) `repository\<<ArtifactName artifact>\>`)
+    = assocRepository("<artifact>");

--- a/src/Parser/Converter/Expression.rsc
+++ b/src/Parser/Converter/Expression.rsc
@@ -92,6 +92,9 @@ public Expression convertExpression((Expression) `new <ArtifactName name>(<{Expr
     
 public Expression convertExpression((Expression) `<MemberName method>(<{Expression ","}* args>)`) 
     = invoke("<method>", [convertExpression(arg) | arg <- args]);
+
+public Expression convertExpression((Expression) `<AssocArtifact a>`) 
+    = assocArtifact(convertAssocArtifact(a));
     
 public Expression convertExpression((Expression) `<Expression prev>.<MemberName method>(<{Expression ","}* args>)`) {
     
@@ -120,6 +123,7 @@ private tuple[Expression key, Expression \value] convertMapPair((MapPair) `<Expr
 
 private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
 private bool isValidForAccessChain((Expression) `this`) = true;
+private bool isValidForAccessChain((Expression) `<AssocArtifact assocArtifact>`) = true;
 private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>`) = true;
 private bool isValidForAccessChain((Expression) `new <ArtifactName name>(<{Expression ","}* args>)`) = true;

--- a/src/Parser/ParseAST.rsc
+++ b/src/Parser/ParseAST.rsc
@@ -4,7 +4,6 @@ import Syntax::Abstract::AST;
 import Syntax::Concrete::Grammar;
 import Parser::ParseCode;
 import ParseTree;
-import Parser::Converter::Module;
 import Parser::Converter;
 
 public Declaration parseModule(str code) = buildAST(parseCode(code));

--- a/src/Syntax/Abstract/AST.rsc
+++ b/src/Syntax/Abstract/AST.rsc
@@ -13,6 +13,7 @@ data Declaration
     | \value(Type \valueType, str name, set[AccessProperty] valueProperties)
     | util(str name, set[Declaration] declarations)
     | inject(str artifactName, str as)
+    | inject(AssocArtifact assocArtifact, str as)
     | relation(RelationDir l, RelationDir r, str name, str as, set[AccessProperty] valueProperties)
     | constructor(list[Declaration] params, list[Statement] body)
     | constructor(list[Declaration] params, list[Statement] body, Expression when)
@@ -23,8 +24,12 @@ data Declaration
     ;
 
 data RelationDir
-    = \one() 
+    = \one()
     | many()
+    ;
+
+data AssocArtifact
+    = assocRepository(str target)
     ;
 
 data UseSource
@@ -78,6 +83,7 @@ data Expression
     | fieldAccess(Expression prev, str field)
     | chain(list[Expression] elements)
     | emptyExpr()
+    | assocArtifact(AssocArtifact aArtifact)
     | this()
     ;
 

--- a/src/Syntax/Concrete/Grammar.rsc
+++ b/src/Syntax/Concrete/Grammar.rsc
@@ -63,6 +63,11 @@ syntax Declaration
     | Modifier? modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "{" Statement* body "}" (When when ";")?
     | Modifier? modifier Type returnType MemberName name "(" {Parameter ","}* parameters ")" "=" Expression expr When? when ";"
     | "inject" ArtifactName artifact "as" MemberName alias ";"
+    | "inject" AssocArtifact assocArtifact "as" MemberName alias ";"
+    ;
+
+syntax AssocArtifact
+    = "repository" "\<" ArtifactName name "\>" 
     ;
 
 syntax Modifier
@@ -124,6 +129,7 @@ syntax Expression
     | newInstance: "new" ArtifactName "(" {Expression ","}* args ")"
     | invoke: (Expression prev ".")? MemberName method "(" {Expression ","}* args ")"
     | fieldAccess: Expression prev "." MemberName field
+    | assocArtifact: AssocArtifact 
     | this: "this"
     > left ( product: Expression lhs "*" () !>> "*" Expression rhs
            | remainder: Expression lhs "%" Expression rhs

--- a/src/Test/Parser/Util/Injections.rsc
+++ b/src/Test/Parser/Util/Injections.rsc
@@ -1,0 +1,52 @@
+module Test::Parser::Util::Injections
+
+import Parser::ParseAST;
+import Syntax::Abstract::AST;
+
+test bool canParseRepositoryInjection() 
+{
+    str code
+        = "module Test;
+          'service UserCreator {
+          '    inject repository\<User\> as userRepository;
+          '}";
+    
+    return parseModule(code) ==
+        \module(namespace("Test"), {}, util("UserCreator", {
+            inject(assocRepository("User"), "userRepository")
+        }));
+}
+
+test bool canParseRepositoryInjection() 
+{
+    str code
+        = "module Test;
+          'service UserCreator {
+          '    inject repository\<User\> as userRepository;
+          '}";
+    
+    return parseModule(code) ==
+        \module(namespace("Test"), {}, util("UserCreator", {
+            inject(assocRepository("User"), "userRepository")
+        }));
+}
+
+test bool canUseRepositoryAssocArtifactInExpression() 
+{
+    str code
+        = "module Test;
+          'service UserCreator {
+          '    UserCreator() {
+          '        repository\<User\>;
+          '        repository\<User\>.findOneById(1);
+          '    }
+          '}";
+    
+    return parseModule(code) ==
+        \module(namespace("Test"), {}, util("UserCreator", {
+            constructor([], [
+                expression(assocArtifact(assocRepository("User"))),
+                expression(invoke(assocArtifact(assocRepository("User")), "findOneById", [intLiteral(1)]))
+            ])
+        }));
+}


### PR DESCRIPTION
#### Description

Adds quick access to repositories
#### Syntax
- `repository <`_`EntityName`_`>`

Can be used in `inject` declaration:

```
module Example;

service Test {
    inject repository<User> as userRepository;
}
```

In addition, can be used in expressions too:

```
module Example;

service Test {
    Test() {
        1 + repository<User>.getSomethingFromHere();
    }
}
```
