### PR TITLE
Type casting

### DIFF
--- a/library/Parser/Converter.rsc
+++ b/library/Parser/Converter.rsc
@@ -269,6 +269,9 @@ public Expression convertExpression(a: (Expression) `{<{MapPair ","}* pairs>}`, 
 private tuple[Expression key, Expression \value] convertMapPair((MapPair) `<Expression key>:<Expression v>`, ParseEnv env)
     = <convertExpression(key, env), convertExpression(v, env)>;
 
+public Expression convertExpression(a: (Expression) `(<Type t>)<Expression expr>`, ParseEnv env) = 
+	cast(convertType(t, env), convertExpression(expr, env))[@src=a@\loc];
+
 private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
 private bool isValidForAccessChain((Expression) `this`) = true;
 private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;

--- a/library/Parser/Converter/Expression.rsc
+++ b/library/Parser/Converter/Expression.rsc
@@ -138,6 +138,9 @@ public Expression convertExpression(a: (Expression) `{<{MapPair ","}* pairs>}`, 
 private tuple[Expression key, Expression \value] convertMapPair((MapPair) `<Expression key>:<Expression v>`, ParseEnv env)
     = <convertExpression(key, env), convertExpression(v, env)>;
 
+public Expression convertExpression(a: (Expression) `(<Type t>)<Expression expr>`, ParseEnv env) = 
+	cast(convertType(t, env), convertExpression(expr, env))[@src=a@\loc];
+
 private bool isValidForAccessChain((Expression) `<MemberName varName>`) = true;
 private bool isValidForAccessChain((Expression) `this`) = true;
 private bool isValidForAccessChain((Expression) `<MemberName method>(<{Expression ","}* args>)`) = true;

--- a/library/Syntax/Abstract/Glagol.rsc
+++ b/library/Syntax/Abstract/Glagol.rsc
@@ -71,6 +71,7 @@ data Expression
     | fieldAccess(Expression prev, str name)
     | emptyExpr()
     | this()
+    | cast(Type \type, Expression expr)
     ;
 
 data Type

--- a/library/Syntax/Concrete/Grammar.rsc
+++ b/library/Syntax/Concrete/Grammar.rsc
@@ -173,6 +173,7 @@ syntax Expression
     | invoke: Expression prev "." MemberName method "(" {Expression ","}* args ")"
     | fieldAccess: Expression prev "." MemberName field
     | this: "this"
+    | "(" Type type ")" Expression expr
     > left ( product: Expression lhs "*" () !>> "*" Expression rhs
            | remainder: Expression lhs "%" Expression rhs
            | division: Expression lhs "/" Expression rhs

--- a/library/Test/Parser/Expressions.rsc
+++ b/library/Test/Parser/Expressions.rsc
@@ -255,6 +255,54 @@ test bool testMethodInvokeUsingThis()
     ]));
 }
 
+test bool testScalarTypeCast()
+{
+    str code = "namespace Example
+               'entity User {
+               '    void methodInvoke() {
+               '        (string) a;
+               '    }
+               '}";
+    
+    return parseModule(code) == \module(namespace("Example"), [], entity("User", [
+        method(\public(), voidValue(), "methodInvoke", [], [
+            expression(cast(string(), variable("a")))
+          ], emptyExpr())
+    ]));
+}
+
+test bool testArtifactTypeCast()
+{
+    str code = "namespace Example
+               'entity User {
+               '    void methodInvoke() {
+               '        (Money) a;
+               '    }
+               '}";
+    
+    return parseModule(code) == \module(namespace("Example"), [], entity("User", [
+        method(\public(), voidValue(), "methodInvoke", [], [
+            expression(cast(artifact(local("Money")), variable("a")))
+          ], emptyExpr())
+    ]));
+}
+
+test bool testRepositoryTypeCast()
+{
+    str code = "namespace Example
+               'entity User {
+               '    void methodInvoke() {
+               '        (repository\<Money\>) a;
+               '    }
+               '}";
+    
+    return parseModule(code) == \module(namespace("Example"), [], entity("User", [
+        method(\public(), voidValue(), "methodInvoke", [], [
+            expression(cast(repository(local("Money")), variable("a")))
+          ], emptyExpr())
+    ]));
+}
+
 test bool shouldFailWhenUsingWrongExpressionsForChainedAccess()
 {
     str code = "namespace Example

--- a/library/Test/Typechecker/Expression.rsc
+++ b/library/Test/Typechecker/Expression.rsc
@@ -820,3 +820,53 @@ test bool shouldReturnUnknownTypeOnAccessingRemoteField() =
 		addToAST(file(|tmp:///|, \module(namespace("Test"), [], entity("User", []))), newEnv(|tmp:///|))
 	));
 
+test bool shouldReturnStringWhenTypeCastingAStringToString() = string() == lookupType(cast(string(), string("dadsa")), newEnv());
+test bool shouldReturnStringWhenTypeCastingAIntegerToString() = string() == lookupType(cast(string(), integer(123)), newEnv());
+test bool shouldReturnStringWhenTypeCastingAFloatToString() = string() == lookupType(cast(string(), float(123.45)), newEnv());
+test bool shouldReturnStringWhenTypeCastingABoolToString() = string() == lookupType(cast(string(), boolean(true)), newEnv());
+test bool shouldReturnUnknownTypeWhenTypeCastingAnUnknownToString() = unknownType() == lookupType(cast(string(), get(string())), newEnv());
+
+test bool shouldReturnIntegerWhenTypeCastingAStringToInteger() = integer() == lookupType(cast(integer(), string("dadsa")), newEnv());
+test bool shouldReturnIntegerWhenTypeCastingAIntegerToInteger() = integer() == lookupType(cast(integer(), integer(123)), newEnv());
+test bool shouldReturnIntegerWhenTypeCastingAFloatToInteger() = integer() == lookupType(cast(integer(), float(123.45)), newEnv());
+test bool shouldReturnIntegerWhenTypeCastingABoolToInteger() = integer() == lookupType(cast(integer(), boolean(true)), newEnv());
+test bool shouldReturnUnknownTypeWhenTypeCastingAnUnknownToInteger() = unknownType() == lookupType(cast(integer(), get(string())), newEnv());
+
+test bool shouldReturnFloatWhenTypeCastingAStringToFloat() = float() == lookupType(cast(float(), string("dadsa")), newEnv());
+test bool shouldReturnFloatWhenTypeCastingAIntegerToFloat() = float() == lookupType(cast(float(), integer(123)), newEnv());
+test bool shouldReturnFloatWhenTypeCastingAFloatToFloat() = float() == lookupType(cast(float(), float(123.45)), newEnv());
+test bool shouldReturnFloatWhenTypeCastingABoolToFloat() = float() == lookupType(cast(float(), boolean(true)), newEnv());
+test bool shouldReturnUnknownTypeWhenTypeCastingAnUnknownToFloat() = unknownType() == lookupType(cast(float(), get(string())), newEnv());
+
+test bool shouldReturnBoolWhenTypeCastingAStringToBool() = boolean() == lookupType(cast(boolean(), string("dadsa")), newEnv());
+test bool shouldReturnBoolWhenTypeCastingAIntegerToBool() = boolean() == lookupType(cast(boolean(), integer(123)), newEnv());
+test bool shouldReturnBoolWhenTypeCastingAFloatToBool() = boolean() == lookupType(cast(boolean(), float(123.45)), newEnv());
+test bool shouldReturnBoolWhenTypeCastingABoolToBool() = boolean() == lookupType(cast(boolean(), boolean(true)), newEnv());
+test bool shouldReturnUnknownTypeWhenTypeCastingAnUnknownToBool() = unknownType() == lookupType(cast(boolean(), get(string())), newEnv());
+
+test bool shouldNotGiveErrorOnStringTypeCastToString() = !hasErrors(checkExpression(cast(string(), string("dadsa")), newEnv()));
+test bool shouldNotGiveErrorOnIntegerTypeCastToString() = !hasErrors(checkExpression(cast(string(), integer(123)), newEnv()));
+test bool shouldNotGiveErrorOnFloatTypeCastToString() = !hasErrors(checkExpression(cast(string(), float(12.453)), newEnv()));
+test bool shouldNotGiveErrorOnBoolTypeCastToString() = !hasErrors(checkExpression(cast(string(), boolean(true)), newEnv()));
+
+test bool shouldNotGiveErrorOnStringTypeCastToInteger() = !hasErrors(checkExpression(cast(integer(), string("dadsa")), newEnv()));
+test bool shouldNotGiveErrorOnIntegerTypeCastToInteger() = !hasErrors(checkExpression(cast(integer(), integer(123)), newEnv()));
+test bool shouldNotGiveErrorOnFloatTypeCastToInteger() = !hasErrors(checkExpression(cast(integer(), float(12.453)), newEnv()));
+test bool shouldNotGiveErrorOnBoolTypeCastToInteger() = !hasErrors(checkExpression(cast(integer(), boolean(true)), newEnv()));
+
+test bool shouldNotGiveErrorOnStringTypeCastToFloat() = !hasErrors(checkExpression(cast(float(), string("dadsa")), newEnv()));
+test bool shouldNotGiveErrorOnIntegerTypeCastToFloat() = !hasErrors(checkExpression(cast(float(), integer(123)), newEnv()));
+test bool shouldNotGiveErrorOnFloatTypeCastToFloat() = !hasErrors(checkExpression(cast(float(), float(12.453)), newEnv()));
+test bool shouldNotGiveErrorOnBoolTypeCastToFloat() = !hasErrors(checkExpression(cast(float(), boolean(true)), newEnv()));
+
+test bool shouldNotGiveErrorOnStringTypeCastToBool() = !hasErrors(checkExpression(cast(boolean(), string("dadsa")), newEnv()));
+test bool shouldNotGiveErrorOnIntegerTypeCastToBool() = !hasErrors(checkExpression(cast(boolean(), integer(123)), newEnv()));
+test bool shouldNotGiveErrorOnFloatTypeCastToBool() = !hasErrors(checkExpression(cast(boolean(), float(12.453)), newEnv()));
+test bool shouldNotGiveErrorOnBoolTypeCastToBool() = !hasErrors(checkExpression(cast(boolean(), boolean(true)), newEnv()));
+
+test bool shouldGiveErrorWhenTypeCastingUnsupportedToString() = 
+	addError(|tmp:///User.g|(0, 0, <20, 20>, <30, 30>), "Type casting string[] to string is not supported", newEnv()) == 
+	checkExpression(cast(string()[@src=|tmp:///User.g|(0, 0, <20, 20>, <30, 30>)], \list([string("dassd")])), newEnv());
+
+
+

--- a/library/Typechecker/Expression.rsc
+++ b/library/Typechecker/Expression.rsc
@@ -279,6 +279,30 @@ public TypeEnv checkInvoke(Type prevType, i: invoke(Expression prev, str m, list
 	
 public TypeEnv checkExpression(emptyExpr(), TypeEnv env) = env;
 public TypeEnv checkExpression(this(), TypeEnv env) = env;
+public TypeEnv checkExpression(cast(Type t, Expression expr), TypeEnv env) = checkCast(t, lookupType(expr, env), env);
+
+public TypeEnv checkCast(string(), string(), TypeEnv env) = env;
+public TypeEnv checkCast(string(), integer(), TypeEnv env) = env;
+public TypeEnv checkCast(string(), float(), TypeEnv env) = env;
+public TypeEnv checkCast(string(), boolean(), TypeEnv env) = env;
+
+public TypeEnv checkCast(integer(), string(), TypeEnv env) = env;
+public TypeEnv checkCast(integer(), integer(), TypeEnv env) = env;
+public TypeEnv checkCast(integer(), float(), TypeEnv env) = env;
+public TypeEnv checkCast(integer(), boolean(), TypeEnv env) = env;
+
+public TypeEnv checkCast(float(), string(), TypeEnv env) = env;
+public TypeEnv checkCast(float(), integer(), TypeEnv env) = env;
+public TypeEnv checkCast(float(), float(), TypeEnv env) = env;
+public TypeEnv checkCast(float(), boolean(), TypeEnv env) = env;
+
+public TypeEnv checkCast(boolean(), string(), TypeEnv env) = env;
+public TypeEnv checkCast(boolean(), integer(), TypeEnv env) = env;
+public TypeEnv checkCast(boolean(), float(), TypeEnv env) = env;
+public TypeEnv checkCast(boolean(), boolean(), TypeEnv env) = env;
+
+public TypeEnv checkCast(Type cast, Type actual, TypeEnv env) = 
+	addError(cast, "Type casting <toString(actual)> to <toString(cast)> is not supported", env);
 
 @doc="Empty expression is always unknown type"
 public Type lookupType(emptyExpr(), _) = unknownType();
@@ -467,6 +491,29 @@ public Type lookupType(artifact(name), f: fieldAccess(str field), TypeEnv env) =
 public Type lookupType(repository(name), f: fieldAccess(str field), TypeEnv env) = lookupType(f, env) when isSelf(name, env);
 public Type lookupType(Type, f: fieldAccess(str field), TypeEnv env) = unknownType();
 
+public Type lookupType(cast(Type t, Expression expr), TypeEnv env) = lookupCastType(t, lookupType(expr, env), env);
+
+public Type lookupCastType(string(), string(), TypeEnv env) = string();
+public Type lookupCastType(string(), integer(), TypeEnv env) = string();
+public Type lookupCastType(string(), float(), TypeEnv env) = string();
+public Type lookupCastType(string(), boolean(), TypeEnv env) = string();
+
+public Type lookupCastType(integer(), string(), TypeEnv env) = integer();
+public Type lookupCastType(integer(), integer(), TypeEnv env) = integer();
+public Type lookupCastType(integer(), float(), TypeEnv env) = integer();
+public Type lookupCastType(integer(), boolean(), TypeEnv env) = integer();
+
+public Type lookupCastType(float(), string(), TypeEnv env) = float();
+public Type lookupCastType(float(), integer(), TypeEnv env) = float();
+public Type lookupCastType(float(), float(), TypeEnv env) = float();
+public Type lookupCastType(float(), boolean(), TypeEnv env) = float();
+
+public Type lookupCastType(boolean(), string(), TypeEnv env) = boolean();
+public Type lookupCastType(boolean(), integer(), TypeEnv env) = boolean();
+public Type lookupCastType(boolean(), float(), TypeEnv env) = boolean();
+public Type lookupCastType(boolean(), boolean(), TypeEnv env) = boolean();
+
+public Type lookupCastType(Type t, Type a, TypeEnv env) = unknownType();
 
 private bool isSelf(local(str name), TypeEnv env) = getContext(env).artifact.name == name;
 private bool isSelf(external(str name, ns, str original), TypeEnv env) = 


### PR DESCRIPTION
The following type casts has been implemented:

- `(string)`_`<expr>`_ 
- `(bool)`_`<expr>`_ 
- `(boolean)`_`<expr>`_ 
- `(int)`_`<expr>`_ 
- `(float)`_`<expr>`_ 